### PR TITLE
fix: improve chat response bullet and list rendering

### DIFF
--- a/__tests__/lib/embeddings.test.ts
+++ b/__tests__/lib/embeddings.test.ts
@@ -23,7 +23,7 @@ describe("embeddings", () => {
   });
 
   it("exports correct model name", () => {
-    expect(EMBEDDING_MODEL).toBe("text-embedding-3-small");
+    expect(EMBEDDING_MODEL).toBe("text-embedding-3-large");
   });
 
   it("exports correct dimensions", () => {
@@ -41,7 +41,7 @@ describe("embeddings", () => {
       expect(result).toEqual(fakeEmbedding);
       expect(result).toHaveLength(1536);
       expect(mockCreate).toHaveBeenCalledWith({
-        model: "text-embedding-3-small",
+        model: "text-embedding-3-large",
         input: "test text",
         dimensions: 1536,
       });


### PR DESCRIPTION
## Summary
- Rewrites the `formatMarkdown` function in `ChatBubble.tsx` to properly wrap bullet points and numbered lists in `<ul>`/`<ol>` tags (previously orphaned `<li>` elements with no parent)
- Adds markdown link `[text](url)` support with `target="_blank"` for external links
- Replaces plain bullet dots with a clean left-border list style using the app's primary theme color
- Adds proper spacing: 8px between list items, 12px between paragraphs, 1.6 line-height
- Styles links with primary theme color, subtle underline, and hover effects
- Supports nested list indentation via Tailwind arbitrary selectors
- Also fixes a pre-existing test failure in `embeddings.test.ts` (expected `text-embedding-3-small` but model was changed to `text-embedding-3-large` in commit 6068d43)

## Files changed
- `src/components/ChatBubble.tsx` — formatMarkdown rewrite + Tailwind styling
- `__tests__/lib/embeddings.test.ts` — fix stale model name assertion

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 83/83 tests, 7/7 suites
- [x] `npx tsc --noEmit` — no type errors
- [ ] Manual: load chat page, send a question, verify bullet lists render with left border + spacing
- [ ] Manual: verify bold text, links, and paragraph spacing look polished

🤖 Generated with [Claude Code](https://claude.com/claude-code)