### PR TITLE
fix: use standard disc bullets with ChatGPT-style prose spacing

### DIFF
--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -59,14 +59,14 @@ export function ChatBubble({ message, onFollowupClick, sessionId }: ChatBubblePr
           {/* Render markdown-like text */}
           <div
             className={[
-              "leading-[1.6]",
+              "leading-7",
               "[&_strong]:font-semibold",
-              "[&_p]:mb-3 [&_p:last-child]:mb-0",
-              "[&_ul]:my-3 [&_ul]:border-l-2 [&_ul]:border-primary/20 [&_ul]:pl-4 [&_ul]:list-none",
-              "[&_ol]:my-3 [&_ol]:border-l-2 [&_ol]:border-primary/20 [&_ol]:pl-4 [&_ol]:list-decimal",
-              "[&_li]:mb-2 [&_li:last-child]:mb-0",
+              "[&_p]:my-4 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0",
+              "[&_ul]:my-4 [&_ul]:list-disc [&_ul]:pl-[1.625em]",
+              "[&_ol]:my-4 [&_ol]:list-decimal [&_ol]:pl-[1.625em]",
+              "[&_li]:my-2 [&_li]:pl-1.5",
               "[&_a]:text-primary [&_a]:underline [&_a]:decoration-primary/30 [&_a]:underline-offset-2 [&_a:hover]:decoration-primary/60",
-              "[&_ul_ul]:mt-2 [&_ul_ul]:mb-0 [&_ol_ol]:mt-2 [&_ol_ol]:mb-0",
+              "[&_ul_ul]:my-2 [&_ol_ol]:my-2 [&_ul_ol]:my-2 [&_ol_ul]:my-2",
             ].join(" ")}
             dangerouslySetInnerHTML={{ __html: formatMarkdown(message.text) }}
           />
@@ -137,8 +137,8 @@ function formatMarkdown(text: string): string {
   let inList: "ul" | "ol" | null = null;
 
   for (const line of lines) {
-    const bulletMatch = line.match(/^[-*]\s+(.+)/);
-    const numberedMatch = line.match(/^\d+\.\s+(.+)/);
+    const bulletMatch = line.match(/^\s*[-*]\s+(.+)/);
+    const numberedMatch = line.match(/^\s*\d+\.\s+(.+)/);
 
     if (bulletMatch) {
       if (inList !== "ul") {


### PR DESCRIPTION
## Summary
- Replaces left-border list styling with standard `list-disc` bullet points (matching ChatGPT, Perplexity, Claude.ai, and Gemini)
- Increases list indentation to `1.625em` (26px) — the same value ChatGPT uses
- Sets line-height to `1.75` (28px via `leading-7`) for readability
- Fixes bullet regex to allow leading whitespace (`^\s*[-*]\s+`) so indented bullets from AI responses are properly detected
- Proper paragraph and list item spacing matching industry standard chat UIs

## What changed
Based on research across all major AI chat UIs, none use decorative borders or custom markers on lists — the polished look comes from standard disc bullets with generous spacing and typography.

## Files changed
- `src/components/ChatBubble.tsx` — styling classes + regex fix

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 83/83 tests, 7/7 suites
- [x] `npx tsc --noEmit` — no type errors
- [ ] Manual: load chat page, send a question with bullet-point response, verify disc bullets render with proper indentation and spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)