### PR TITLE
fix: support 1) numbered list format in chat response rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,8 @@ npx tsc --noEmit
 After all checks pass, you MUST let the user preview before pushing:
 1. Start the dev server: `npx next dev -p 3000`
 2. Tell the user: "All checks pass. Preview your changes at http://localhost:3000/needham - let me know if it looks good or if you want changes."
-3. **STOP and WAIT** for the user to respond.
+3. **Include a specific change summary** listing every file changed, what was modified (before → after), and why. The user should know exactly what to look for when previewing.
+4. **STOP and WAIT** for the user to respond.
 4. If the user requests changes, make them and go back to Step 1.
 5. Only proceed to Step 4 after the user explicitly approves.
 

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -138,7 +138,7 @@ function formatMarkdown(text: string): string {
 
   for (const line of lines) {
     const bulletMatch = line.match(/^\s*[-*]\s+(.+)/);
-    const numberedMatch = line.match(/^\s*\d+\.\s+(.+)/);
+    const numberedMatch = line.match(/^\s*\d+[.)]\s+(.+)/);
 
     if (bulletMatch) {
       if (inList !== "ul") {


### PR DESCRIPTION
## Summary
- Updated `formatMarkdown()` regex in `ChatBubble.tsx` to match both `1.` and `1)` numbered list formats (changed `\d+\.` → `\d+[.)]`)
- Both formats now render as styled `<ol><li>` elements with proper indentation and spacing
- Added mandatory change-summary rule to CLAUDE.md pre-push checkpoint

## Test plan
- [ ] Open chat at `/needham/chat`
- [ ] Ask a question that returns a numbered list (e.g., "What are the steps to get a building permit?")
- [ ] Verify numbers display as styled ordered list, not plain text like `1)`
- [ ] Verify bullet lists still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)