### PR TITLE
fix: explicitly delete head branch after auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,12 @@ jobs:
               merge_method: 'squash'
             });
 
+      - name: Delete merged branch
+        if: success()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${{ github.event.pull_request.head.ref }}" || true
+
   on-failure:
     needs: build-and-test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds explicit branch deletion step to the auto-merge workflow. The GitHub auto-delete setting doesn't reliably fire for API-based merges.