### PR TITLE
feat: add Vercel cron job for daily content monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ LLAMAPARSE_API_KEY=llx-...
 # Admin dashboard password
 ADMIN_PASSWORD=changeme
 
+# Vercel Cron secret — used to authenticate scheduled cron requests
+# Generate with: openssl rand -hex 32
+# Set in Vercel Dashboard > Settings > Environment Variables
+CRON_SECRET=
+
 # Mock data toggle — Set to "true" to use mock chat responses for testing/demos
 # Set to "false" or omit to use real RAG-powered API responses
 NEXT_PUBLIC_USE_MOCK_DATA=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,17 @@ Every agent session MUST start with these steps before writing any new code:
 
 Branch naming: `feature/<name>`, `fix/<name>`, `setup/<name>`, `data/<name>`
 
+## Vercel Cron Jobs
+- **Daily Monitor** (`/api/cron/monitor`): Runs at 6:00 AM UTC (1:00 AM Eastern) via `vercel.json`
+  - Checks tracked needhamma.gov pages for content-hash changes
+  - Monitors RSS feed for new pages
+  - Flags documents not verified in 90+ days as stale
+  - Logs results to `ingestion_log` table with `triggered_by: "vercel-cron"`
+  - Secured by `CRON_SECRET` Bearer token (set in Vercel Dashboard)
+  - Core logic in `src/lib/monitor.ts`, route in `src/app/api/cron/monitor/route.ts`
+- **Connector Ingest** (`/api/cron/ingest`): Runs connectors on schedule
+- **Sync** (`/api/cron/sync`): Legacy sync endpoint (predecessor to monitor)
+
 ## CI/CD Pipeline Status
 - **Last validated:** 2026-02-12
 - **Pipeline:** GitHub Actions (ci.yml) > auto-merge > Vercel deploy

--- a/src/app/api/cron/monitor/route.ts
+++ b/src/app/api/cron/monitor/route.ts
@@ -1,0 +1,49 @@
+/**
+ * /api/cron/monitor — Daily content change detection
+ *
+ * Triggered by Vercel Cron (daily at 6:00 AM UTC / 1:00 AM Eastern).
+ * Checks tracked needhamma.gov pages for content changes via hash
+ * comparison, monitors RSS for new pages, and flags stale documents.
+ *
+ * Security: Protected by CRON_SECRET Bearer token.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { runChangeDetection } from "@/lib/monitor";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // 5 minutes max for cron jobs
+
+export async function GET(request: NextRequest) {
+  // Verify cron secret (skip in development)
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  try {
+    const result = await runChangeDetection("needham", "vercel-cron");
+
+    return NextResponse.json({
+      status: "completed",
+      timestamp: new Date().toISOString(),
+      checked: result.checkedUrls,
+      changed: result.changedUrls.length,
+      changedUrls: result.changedUrls,
+      newUrls: result.newUrls,
+      errors: result.errors,
+      durationMs: result.durationMs,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[cron/monitor] Fatal error:", message);
+    return NextResponse.json(
+      { error: message, timestamp: new Date().toISOString() },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/monitor.ts
+++ b/src/lib/monitor.ts
@@ -1,0 +1,216 @@
+/**
+ * src/lib/monitor.ts — Change detection for tracked documents
+ *
+ * Ported from scripts/monitor.ts so it can be imported by Next.js API routes
+ * (scripts/ is excluded from tsconfig). The logic is identical:
+ * 1. Checks tracked documents for content-hash changes
+ * 2. Checks CivicPlus RSS feed for new pages
+ * 3. Flags stale documents (not verified in 90 days)
+ * 4. Logs results to Supabase ingestion_log
+ */
+
+import { createHash } from "crypto";
+import { getSupabaseServiceClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ChangeDetectionResult {
+  checkedUrls: number;
+  changedUrls: string[];
+  newUrls: string[];
+  removedUrls: string[];
+  errors: number;
+  durationMs: number;
+}
+
+interface TrackedDocument {
+  id: string;
+  url: string;
+  content_hash: string | null;
+  source_type: "html" | "pdf" | null;
+  metadata: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Content-hash-based change detection
+// ---------------------------------------------------------------------------
+
+function hashContent(content: string | Buffer): string {
+  return createHash("sha256")
+    .update(typeof content === "string" ? content : content)
+    .digest("hex");
+}
+
+async function checkUrlForChanges(
+  doc: TrackedDocument
+): Promise<{ changed: boolean; newHash: string | null; error?: string }> {
+  try {
+    if (doc.source_type === "html") {
+      const response = await fetch(doc.url);
+      if (!response.ok) {
+        return { changed: false, newHash: null, error: `HTTP ${response.status}` };
+      }
+      const html = await response.text();
+      const newHash = hashContent(html);
+      return { changed: newHash !== doc.content_hash, newHash };
+    }
+
+    if (doc.source_type === "pdf") {
+      const response = await fetch(doc.url);
+      if (!response.ok) {
+        return { changed: false, newHash: null, error: `HTTP ${response.status}` };
+      }
+      const arrayBuffer = await response.arrayBuffer();
+      const pdfBuffer = Buffer.from(arrayBuffer);
+      const newHash = hashContent(pdfBuffer.toString("base64"));
+      return { changed: newHash !== doc.content_hash, newHash };
+    }
+
+    return { changed: false, newHash: null };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error(`[monitor] Error checking ${doc.url}:`, errorMessage);
+    return { changed: false, newHash: null, error: errorMessage };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RSS feed check
+// ---------------------------------------------------------------------------
+
+async function checkRssFeed(rssFeedUrl: string): Promise<string[]> {
+  try {
+    const response = await fetch(rssFeedUrl);
+    if (!response.ok) {
+      console.warn(`[monitor] RSS fetch failed: ${response.status}`);
+      return [];
+    }
+    const xml = await response.text();
+    const linkRegex = /<link>([^<]+)<\/link>/g;
+    const urls: string[] = [];
+    let match;
+    while ((match = linkRegex.exec(xml)) !== null) {
+      const url = match[1].trim();
+      if (url.startsWith("http")) urls.push(url);
+    }
+    console.log(`[monitor] RSS feed returned ${urls.length} URLs`);
+    return urls;
+  } catch (err) {
+    console.error("[monitor] RSS check failed:", err);
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main monitoring function
+// ---------------------------------------------------------------------------
+
+export async function runChangeDetection(
+  townId: string = "needham",
+  triggeredBy: string = "cli"
+): Promise<ChangeDetectionResult> {
+  const startTime = Date.now();
+  const supabase = getSupabaseServiceClient();
+  let errorCount = 0;
+
+  // Stage 1: Fetch tracked documents
+  console.log(`[monitor] Fetching tracked documents for town: ${townId}`);
+  const { data: documents, error: fetchError } = await supabase
+    .from("documents")
+    .select("id, url, content_hash, source_type, metadata")
+    .eq("town_id", townId);
+
+  if (fetchError) {
+    throw new Error(`Failed to fetch documents: ${fetchError.message}`);
+  }
+
+  const tracked = (documents || []) as TrackedDocument[];
+  console.log(`[monitor] Found ${tracked.length} tracked documents`);
+
+  // Stage 2: Content-hash change detection
+  const changedUrls: string[] = [];
+
+  for (const doc of tracked) {
+    const { changed, newHash, error } = await checkUrlForChanges(doc);
+
+    if (error) {
+      errorCount++;
+      continue;
+    }
+
+    if (changed) {
+      changedUrls.push(doc.url);
+      const now = new Date().toISOString();
+      await supabase
+        .from("documents")
+        .update({
+          content_hash: newHash,
+          last_verified_at: now,
+          is_stale: false,
+          metadata: { ...doc.metadata, last_changed: now, last_checked: now },
+        })
+        .eq("id", doc.id);
+    } else {
+      const now = new Date().toISOString();
+      await supabase
+        .from("documents")
+        .update({
+          last_verified_at: now,
+          metadata: { ...doc.metadata, last_checked: now },
+        })
+        .eq("id", doc.id);
+    }
+  }
+
+  console.log(`[monitor] ${changedUrls.length} changed, ${errorCount} errors`);
+
+  // Stage 3: RSS feed check
+  const rssUrls = await checkRssFeed("https://www.needhamma.gov/rss.aspx");
+  const existingUrls = new Set(tracked.map((d) => d.url));
+  const newUrls = rssUrls.filter((u) => !existingUrls.has(u));
+  console.log(`[monitor] ${newUrls.length} new URLs from RSS`);
+
+  // Stage 4: Staleness flagging
+  const ninetyDaysAgo = new Date();
+  ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
+  const { error: staleError } = await supabase
+    .from("documents")
+    .update({ is_stale: true })
+    .eq("town_id", townId)
+    .lt("last_verified_at", ninetyDaysAgo.toISOString());
+
+  if (staleError) {
+    errorCount++;
+    console.error(`[monitor] Error flagging stale docs: ${staleError.message}`);
+  }
+
+  const durationMs = Date.now() - startTime;
+
+  // Log to ingestion_log
+  await supabase.from("ingestion_log").insert({
+    town_id: townId,
+    action: "monitor",
+    documents_processed: tracked.length,
+    errors: errorCount,
+    duration_ms: durationMs,
+    details: {
+      changed_urls: changedUrls,
+      new_urls: newUrls,
+      checked_at: new Date().toISOString(),
+      triggered_by: triggeredBy,
+    },
+  });
+
+  console.log(`[monitor] Complete in ${durationMs}ms`);
+
+  return {
+    checkedUrls: tracked.length,
+    changedUrls,
+    newUrls,
+    removedUrls: [],
+    errors: errorCount,
+    durationMs,
+  };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/monitor",
+      "schedule": "0 6 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds Vercel Cron configuration (`vercel.json`) to run content monitoring daily at 6:00 AM UTC (1:00 AM Eastern)
- Creates `/api/cron/monitor` API route secured with `CRON_SECRET` Bearer token
- Ports change detection logic from `scripts/monitor.ts` into `src/lib/monitor.ts` (scripts/ is excluded from tsconfig)
- Checks 500+ tracked needhamma.gov pages for content-hash changes, monitors RSS for new pages, flags stale docs

## Test plan
- [x] `npm run build` passes (route shows as `ƒ /api/cron/monitor`)
- [x] `npm test` passes (83 tests, 7 suites)
- [x] `npx tsc --noEmit` passes
- [x] Live-tested endpoint locally with real Supabase creds: found 500 docs, detected 325 changes, 0 errors
- [ ] After merge: set `CRON_SECRET` env var in Vercel Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)