### PR TITLE
fix: replace hardcoded system prompt with RAG sibling chunk expansion

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -143,7 +143,6 @@ export async function POST(request: Request): Promise<Response> {
       chunks = await retrieveRelevantChunks(latestUserMessage.content, {
         townId,
         matchThreshold: 0.30,
-        matchCount: 20,
       });
     } catch (retrievalError) {
       console.error("[api/chat] Retrieval failed, returning fallback:", retrievalError);

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -13,7 +13,7 @@ NEEDHAM-SPECIFIC CONTEXT:
 - MBTA Communities zoning is a major current topic affecting residential development
 - Town Meeting is the legislative body; the Select Board is the executive branch
 - Three MBTA commuter rail stations: Needham Heights, Needham Center, Needham Junction
-- Annual Transfer Station stickers are required and cost $200-$365 depending on vehicle type. Stickers can be obtained in person at the Town Clerk's office (1471 Highland Ave, during business hours) or by mail (send completed application + SASE to Town Clerk's Office, Needham Town Hall, 1471 Central Avenue, Needham, MA 02492). For questions call the RTS at (781) 455-7568.
+- Annual Transfer Station stickers are required and cost $200-$365 depending on vehicle type
 - Town Hall: (781) 455-7500
 
 RESPONSE FORMAT:


### PR DESCRIPTION
## Summary
- **Removes hardcoded transfer station sticker instructions** from the system prompt — answers should come from RAG-retrieved documents, not baked-in text
- **Adds sibling chunk expansion** to the RAG selection pipeline: after picking top 8 chunks (with per-doc cap of 3 for diversity), fills remaining 2 slots preferring adjacent chunks (same `document_url`, `chunk_index` ±1) from already-selected documents
- **Removes `matchCount: 20` bottleneck** in the chat route so retrieval uses the default 30 candidates for better reranking coverage

## Test plan
- [ ] Build passes (`npx next build`)
- [ ] Ask "how do I get a dump sticker?" in chat
- [ ] Verify both in-person and by-mail methods appear in the AI response
- [ ] Confirm the answer comes from RAG context (not hardcoded prompt) by checking source chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)