### PR TITLE
feat: add OpenAI cost tracking and admin dashboard

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,32 @@
 
 ---
 
+## v0.8.5 — 2026-02-13
+
+**OpenAI Cost Tracking & Admin Dashboard**
+
+### New Features
+- **Automatic cost logging**: Every chat API call now logs token usage (input/output tokens) and estimated USD cost to the `api_costs` table — fully async, does not slow down responses
+- **Cost monitor dashboard**: New "Costs" tab in `/admin` with:
+  - Today / This Week / This Month summary cards
+  - Projected monthly cost (extrapolated from daily average)
+  - Average cost per query, total requests, total tokens
+  - Daily cost bar chart (last 30 days) with hover tooltips
+  - Cost-by-model breakdown with progress bars
+  - Friendly empty state when no data exists yet
+- **Cost API endpoint**: `GET /api/admin/costs` returns cost summary JSON (admin-protected)
+- **Model pricing constants**: `MODEL_COSTS` in `src/lib/cost-tracker.ts` maps all supported models to per-token pricing for easy updates
+
+### Database
+- **Migration:** `002_cost_tracking.sql` — creates `api_costs` table with indexes on `created_at`, `endpoint`, and `town_id`
+
+### Technical
+- Uses Vercel AI SDK v6 `result.usage` promise for non-blocking token tracking
+- Gracefully handles missing `api_costs` table (shows empty state, no errors)
+- Fire-and-forget logging pattern — cost tracking failures never affect chat responses
+
+---
+
 ## v0.8.4 — 2026-02-12
 
 **Embedding Model Migration: text-embedding-3-small → text-embedding-3-large**

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -96,6 +96,7 @@ The home page lists key town departments with phone numbers. Click any departmen
 Visit `/admin` to access:
 
 - **Analytics** — feedback trends, query volume, response quality metrics
+- **Costs** — OpenAI API spend monitoring: today/week/month totals, projected monthly cost, daily cost chart (last 30 days), cost-by-model breakdown, average cost per query
 - **System Logs** — ingestion status, error tracking, sync history
 - **Document Management** — view indexed content and sources
 - **Settings** — configure the AI chat model (GPT-5 Nano, GPT-5 Mini, GPT-4o Mini, GPT-4.1 Mini) with pricing info; changes take effect immediately

--- a/src/app/api/admin/costs/route.ts
+++ b/src/app/api/admin/costs/route.ts
@@ -1,0 +1,17 @@
+import { isAdminAuthorized, unauthorizedAdminResponse } from "@/lib/admin-auth";
+import { getCostSummary } from "@/lib/cost-tracker";
+
+export async function GET(request: Request): Promise<Response> {
+  if (!isAdminAuthorized(request)) return unauthorizedAdminResponse();
+
+  const { searchParams } = new URL(request.url);
+  const townId = searchParams.get("town")?.trim() || "needham";
+
+  try {
+    const summary = await getCostSummary(townId);
+    return Response.json(summary);
+  } catch (error) {
+    const details = error instanceof Error ? error.message : "Unexpected cost API error.";
+    return Response.json({ error: "Unable to load cost data.", details }, { status: 500 });
+  }
+}

--- a/src/lib/cost-tracker.ts
+++ b/src/lib/cost-tracker.ts
@@ -1,0 +1,190 @@
+import { getSupabaseServiceClient } from "@/lib/supabase";
+
+// ---------------------------------------------------------------------------
+// Model pricing (USD per 1M tokens) — update when prices change
+// ---------------------------------------------------------------------------
+
+export const MODEL_COSTS: Record<string, { input: number; output: number }> = {
+  // Chat models
+  "gpt-5-nano":                { input: 0.10, output: 0.40 },
+  "gpt-5-mini":                { input: 0.30, output: 1.20 },
+  "gpt-4o-mini":               { input: 0.15, output: 0.60 },
+  "gpt-4.1-mini":              { input: 0.40, output: 1.60 },
+  // Embedding models
+  "text-embedding-3-small":    { input: 0.02, output: 0 },
+  "text-embedding-3-large":    { input: 0.13, output: 0 },
+};
+
+// ---------------------------------------------------------------------------
+// Calculate cost from token counts
+// ---------------------------------------------------------------------------
+
+export function calculateCost(
+  model: string,
+  promptTokens: number,
+  completionTokens: number,
+): number {
+  const pricing = MODEL_COSTS[model];
+  if (!pricing) return 0;
+  return (promptTokens * pricing.input + completionTokens * pricing.output) / 1_000_000;
+}
+
+// ---------------------------------------------------------------------------
+// Log a single API cost to the database (fire-and-forget)
+// ---------------------------------------------------------------------------
+
+export interface TrackCostParams {
+  townId?: string;
+  endpoint: string;
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  metadata?: Record<string, unknown>;
+}
+
+export async function trackCost(params: TrackCostParams): Promise<void> {
+  const estimatedCost = calculateCost(params.model, params.promptTokens, params.completionTokens);
+  const supabase = getSupabaseServiceClient();
+
+  const { error } = await supabase.from("api_costs").insert({
+    town_id: params.townId ?? "needham",
+    endpoint: params.endpoint,
+    model: params.model,
+    prompt_tokens: params.promptTokens,
+    completion_tokens: params.completionTokens,
+    total_tokens: params.totalTokens,
+    estimated_cost_usd: estimatedCost,
+    metadata: params.metadata ?? null,
+  });
+
+  if (error) {
+    console.error("[cost-tracker] Failed to log cost:", error.message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cost summary for the admin dashboard
+// ---------------------------------------------------------------------------
+
+export interface PeriodSummary {
+  total_cost: number;
+  total_requests: number;
+  total_tokens: number;
+}
+
+export interface DailyBreakdown {
+  date: string;
+  cost: number;
+  requests: number;
+  tokens: number;
+}
+
+export interface ModelBreakdown {
+  model: string;
+  cost: number;
+  requests: number;
+}
+
+export interface CostSummary {
+  today: PeriodSummary;
+  week: PeriodSummary;
+  month: PeriodSummary;
+  daily: DailyBreakdown[];
+  by_model: ModelBreakdown[];
+}
+
+export async function getCostSummary(townId: string = "needham"): Promise<CostSummary> {
+  const supabase = getSupabaseServiceClient();
+
+  // Fetch last 30 days of cost data
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  const { data: rows, error } = await supabase
+    .from("api_costs")
+    .select("estimated_cost_usd, total_tokens, model, created_at")
+    .eq("town_id", townId)
+    .gte("created_at", thirtyDaysAgo.toISOString())
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    // Table may not exist yet (migration not run) — return empty data
+    // so the UI shows the friendly "no data yet" state instead of an error.
+    if (error.code === "42P01" || error.message.includes("api_costs")) {
+      const empty: PeriodSummary = { total_cost: 0, total_requests: 0, total_tokens: 0 };
+      return { today: { ...empty }, week: { ...empty }, month: { ...empty }, daily: [], by_model: [] };
+    }
+    throw new Error(`Failed to fetch cost data: ${error.message}`);
+  }
+
+  const allRows = (rows ?? []) as Array<{
+    estimated_cost_usd: number;
+    total_tokens: number;
+    model: string;
+    created_at: string;
+  }>;
+
+  const now = new Date();
+  const todayStr = now.toISOString().slice(0, 10);
+
+  const startOfWeek = new Date(now);
+  startOfWeek.setDate(now.getDate() - now.getDay());
+  startOfWeek.setHours(0, 0, 0, 0);
+
+  const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+  const today: PeriodSummary = { total_cost: 0, total_requests: 0, total_tokens: 0 };
+  const week: PeriodSummary = { total_cost: 0, total_requests: 0, total_tokens: 0 };
+  const month: PeriodSummary = { total_cost: 0, total_requests: 0, total_tokens: 0 };
+
+  const dailyMap = new Map<string, { cost: number; requests: number; tokens: number }>();
+  const modelMap = new Map<string, { cost: number; requests: number }>();
+
+  for (const row of allRows) {
+    const cost = Number(row.estimated_cost_usd);
+    const tokens = row.total_tokens;
+    const date = new Date(row.created_at);
+    const dateStr = date.toISOString().slice(0, 10);
+
+    // Daily aggregation
+    const daily = dailyMap.get(dateStr) ?? { cost: 0, requests: 0, tokens: 0 };
+    daily.cost += cost;
+    daily.requests += 1;
+    daily.tokens += tokens;
+    dailyMap.set(dateStr, daily);
+
+    // Model aggregation
+    const model = modelMap.get(row.model) ?? { cost: 0, requests: 0 };
+    model.cost += cost;
+    model.requests += 1;
+    modelMap.set(row.model, model);
+
+    // Period aggregation
+    if (dateStr === todayStr) {
+      today.total_cost += cost;
+      today.total_requests += 1;
+      today.total_tokens += tokens;
+    }
+    if (date >= startOfWeek) {
+      week.total_cost += cost;
+      week.total_requests += 1;
+      week.total_tokens += tokens;
+    }
+    if (date >= startOfMonth) {
+      month.total_cost += cost;
+      month.total_requests += 1;
+      month.total_tokens += tokens;
+    }
+  }
+
+  const daily: DailyBreakdown[] = Array.from(dailyMap.entries())
+    .map(([date, d]) => ({ date, cost: d.cost, requests: d.requests, tokens: d.tokens }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  const by_model: ModelBreakdown[] = Array.from(modelMap.entries())
+    .map(([model, m]) => ({ model, cost: m.cost, requests: m.requests }))
+    .sort((a, b) => b.cost - a.cost);
+
+  return { today, week, month, daily, by_model };
+}

--- a/supabase/migrations/002_cost_tracking.sql
+++ b/supabase/migrations/002_cost_tracking.sql
@@ -1,0 +1,26 @@
+-- ============================================================================
+-- Migration: 002_cost_tracking.sql
+-- Description: Creates the api_costs table for tracking OpenAI API spend
+--              per request (chat completions, embeddings, etc.).
+--
+-- NOTE: Run this migration manually in the Supabase SQL Editor, the same way
+--       as the initial migration. Go to SQL Editor > New Query, paste this
+--       file's contents, and click Run.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS api_costs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  town_id TEXT NOT NULL DEFAULT 'needham',
+  endpoint TEXT NOT NULL,              -- 'chat', 'embedding', 'content'
+  model TEXT NOT NULL,                 -- 'gpt-4o-mini', 'gpt-5-nano', 'text-embedding-3-small', etc.
+  prompt_tokens INTEGER NOT NULL DEFAULT 0,
+  completion_tokens INTEGER NOT NULL DEFAULT 0,
+  total_tokens INTEGER NOT NULL DEFAULT 0,
+  estimated_cost_usd NUMERIC(10, 8) NOT NULL DEFAULT 0,
+  metadata JSONB,                      -- optional: question length, source count, etc.
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_api_costs_created_at ON api_costs(created_at DESC);
+CREATE INDEX idx_api_costs_endpoint ON api_costs(endpoint);
+CREATE INDEX idx_api_costs_town_id ON api_costs(town_id);


### PR DESCRIPTION
## Summary
- Logs token usage and estimated USD cost for every chat API call (async, non-blocking)
- New **Costs** tab in `/admin` with today/week/month summary cards, daily cost bar chart (30 days), cost-by-model breakdown, avg cost per query, and projected monthly cost
- `GET /api/admin/costs` endpoint (admin-protected)
- `api_costs` Supabase table with migration (already applied to production)
- Graceful degradation: shows friendly empty state if table doesn't exist or has no data

## Files changed
| File | Change |
|------|--------|
| `supabase/migrations/002_cost_tracking.sql` | New migration for `api_costs` table |
| `src/lib/cost-tracker.ts` | New utility: `trackCost()`, `getCostSummary()`, `MODEL_COSTS` |
| `src/app/api/admin/costs/route.ts` | New admin-protected cost summary endpoint |
| `src/app/api/chat/route.ts` | Added async cost logging after `streamText()` |
| `src/app/admin/page.tsx` | Added Costs tab with charts and KPI cards |
| `docs/USER_GUIDE.md` | Added Costs section to admin docs |
| `docs/RELEASE_NOTES.md` | Added v0.8.5 entry |

## Note
The Supabase migration (`002_cost_tracking.sql`) has already been applied to the database via `supabase db push`.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 83 tests pass
- [x] `npx tsc --noEmit` — zero type errors
- [x] Admin dashboard loads, Costs tab shows empty state
- [x] All other tabs (Documents, Analytics, Logs, Settings) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)