### PR TITLE
refactor: make system prompt multi-tenant, remove hardcoded Needham data

### DIFF
--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -154,7 +154,7 @@ import {
 import { dedupeSources, buildContextDocuments } from "@/lib/rag";
 import {
     buildChatSystemPrompt,
-    FIRST_MESSAGE_DISCLAIMER,
+    getFirstMessageDisclaimer,
 } from "@/lib/prompts";
 
 // ===========================================================================
@@ -432,10 +432,12 @@ describe("Test 10 — Legal Disclaimer", () => {
         const prompt = buildChatSystemPrompt({
             contextDocuments: [],
             includeDisclaimer: true,
+            townName: "Needham, MA",
+            townHallPhone: "(781) 455-7500",
         });
 
-        // The disclaimer constant as defined in prompts.ts
-        expect(prompt).toContain(FIRST_MESSAGE_DISCLAIMER);
+        // The disclaimer should be generated dynamically with the town phone
+        expect(prompt).toContain(getFirstMessageDisclaimer("(781) 455-7500"));
         expect(prompt).toContain(
             "This tool uses AI and may provide inaccurate information",
         );
@@ -446,6 +448,8 @@ describe("Test 10 — Legal Disclaimer", () => {
         const prompt = buildChatSystemPrompt({
             contextDocuments: [],
             includeDisclaimer: false,
+            townName: "Needham, MA",
+            townHallPhone: "(781) 455-7500",
         });
 
         expect(prompt).not.toContain("FIRST-MESSAGE DISCLAIMER");

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,23 @@
 
 ---
 
+## v0.8.6 — 2026-02-13
+
+**Multi-Tenant System Prompt — Remove Hardcoded Needham Data**
+
+### Bug Fixes
+- **System prompt no longer hardcodes Needham-specific facts** (Transfer Station address, MBTA stations, sticker prices, Town Hall phone). All town-specific facts now come from RAG retrieval, making the prompt fully multi-tenant.
+- **Fallback "call Town Hall" message** now uses the correct phone number from the town's config instead of a hardcoded `(781) 455-7500`
+- **Synonym expansions** no longer embed factual data (addresses, dates) — only genuine informal→formal query mappings remain
+
+### Technical
+- `buildChatSystemPrompt()` now accepts `townName` and `townHallPhone` parameters
+- `FIRST_MESSAGE_DISCLAIMER` constant replaced with `getFirstMessageDisclaimer(townHallPhone)` function
+- Chat route looks up town config via `getTownById()` and passes dynamic values to prompt builder
+- Removed `"1421 Central Avenue"` and `"first Monday in May"` from synonym expansions in `synonyms.ts`
+
+---
+
 ## v0.8.5 — 2026-02-13
 
 **OpenAI Cost Tracking & Admin Dashboard**

--- a/src/lib/synonyms.ts
+++ b/src/lib/synonyms.ts
@@ -166,7 +166,7 @@ const TOWN_SYNONYMS: Record<string, SynonymDictionary> = {
   needham: [
     {
       triggers: ["the dump", "rts"],
-      expansions: ["Needham Transfer Station", "1421 Central Avenue", "recycling and transfer station"],
+      expansions: ["Needham Transfer Station", "recycling and transfer station"],
     },
     {
       triggers: ["the rec", "rec center"],
@@ -190,7 +190,7 @@ const TOWN_SYNONYMS: Record<string, SynonymDictionary> = {
     },
     {
       triggers: ["town meeting"],
-      expansions: ["Needham Town Meeting", "first Monday in May"],
+      expansions: ["Needham Town Meeting", "annual town meeting"],
     },
     {
       triggers: ["override", "prop 2.5", "proposition 2 1/2"],


### PR DESCRIPTION
## Summary
- **Deleted the entire `NEEDHAM-SPECIFIC CONTEXT` section** from the system prompt — Transfer Station address, MBTA stations, sticker prices, and Town Hall phone were all hardcoded. These facts are already in the RAG pipeline from crawled needhamma.gov pages.
- **Parameterized `buildChatSystemPrompt()`** to accept `townName` and `townHallPhone`, making the prompt fully multi-tenant
- **Fixed hardcoded fallback phone** in chat route — now dynamically pulled from `config/towns.ts` via `getTownById()`
- **Cleaned up synonym expansions** — removed `"1421 Central Avenue"` (an address) and `"first Monday in May"` (a date) which are facts, not synonyms

## Test plan
- [x] `npm run build` — passes
- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — 83/83 passing
- [ ] Verify `/needham/chat` — ask "where's the dump?" → answer should come from RAG, not hardcoded prompt
- [ ] Verify `/mock-town/chat` — prompt should reference "Mock Town, MA", not "Needham"
- [ ] Verify fallback message shows correct phone for each town

🤖 Generated with [Claude Code](https://claude.com/claude-code)