### PR TITLE
Add RAG quality evaluation with verified golden test dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,34 @@ This is primarily a portfolio project, but suggestions and bug reports are welco
 ---
 
 *Questions or feedback? Open an issue or reach out via the repository.*
+
+---
+
+## RAG Quality Evaluation
+
+The project includes a golden test dataset and evaluation tooling to measure RAG pipeline quality against verified ground-truth answers from needhamma.gov.
+
+### Golden Test Dataset
+
+`docs/golden-test-dataset-verified.json` contains 73 questions spanning 14 categories (Transfer Station, Taxes, Schools, Zoning, Permits, etc.) with:
+- **Verified answer facts** — specific strings the response should contain
+- **Verification status** — `verified`, `partially_verified`
+- **Difficulty levels** — Easy, Medium, Hard
+- **Persona context** — New Resident, Concerned Citizen, Homeowner, Real Estate Agent, Small Business Owner
+
+### Running the Evaluation
+
+1. Start the dev server: `npm run dev`
+2. Run the eval: `npm run eval` — sends each question to the Chat API, scores responses, saves results to `docs/eval-results-YYYY-MM-DD.json`
+3. Generate the scorecard: `npm run eval:scorecard` — produces `docs/eval-scorecard-YYYY-MM-DD.md` with category breakdowns, worst/best questions, response time stats, and improvement recommendations
+
+### Scorecard Sections
+
+- **Overall score** (0–100%) with fact-level precision
+- **Score by category** — identifies weak topic areas
+- **Score by difficulty** — Easy vs Medium vs Hard
+- **Score by verification status** — verified vs partially_verified
+- **Top 10 worst questions** — with missing facts listed
+- **Top 10 best questions**
+- **Response time stats** — avg, P50, P95, slowest
+- **Recommendations** — actionable next steps for RAG improvement

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "ingest": "tsx scripts/ingest.ts",
     "crawl": "tsx scripts/crawl.ts",
     "monitor": "tsx scripts/monitor.ts",
-    "validate": "tsx scripts/validate-ingestion.ts"
+    "validate": "tsx scripts/validate-ingestion.ts",
+    "eval": "tsx scripts/eval-golden-test.ts",
+    "eval:scorecard": "tsx scripts/eval-scorecard.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.26",

--- a/scripts/eval-golden-test.ts
+++ b/scripts/eval-golden-test.ts
@@ -1,0 +1,321 @@
+/**
+ * RAG Quality Evaluation — Golden Test Runner
+ *
+ * Reads docs/golden-test-dataset-verified.json, sends each question to the
+ * local Chat API, scores the response against verified_answer_contains via
+ * case-insensitive substring matching, and writes results to
+ * docs/eval-results-YYYY-MM-DD.json.
+ *
+ * Usage:  npx tsx scripts/eval-golden-test.ts
+ * Requires:  dev server running at http://localhost:3000
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type GoldenQuestion = {
+  id: string;
+  persona: string;
+  category: string;
+  question: string;
+  verified_answer_contains: string[];
+  verified_source_urls: string[];
+  verification_status: string;
+  expected_confidence: string;
+  difficulty: string;
+  notes: string;
+};
+
+type FactResult = {
+  fact: string;
+  found: boolean;
+};
+
+type QuestionResult = {
+  id: string;
+  category: string;
+  difficulty: string;
+  verification_status: string;
+  question: string;
+  response: string;
+  facts: FactResult[];
+  facts_found: number;
+  total_facts: number;
+  score: number;
+  response_time_ms: number;
+  error: string | null;
+};
+
+type EvalResults = {
+  run_date: string;
+  api_url: string;
+  town_id: string;
+  total_questions: number;
+  results: QuestionResult[];
+};
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const API_URL = "http://localhost:3000/api/chat";
+const TOWN_ID = "needham";
+const DELAY_MS = 1000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Parse a UIMessageStream SSE response and extract the concatenated text.
+ *
+ * The stream sends lines like:
+ *   data: {"type":"text-delta","id":"...","delta":"some text"}
+ *
+ * We accumulate all text-delta payloads.
+ */
+function parseSSEText(raw: string): string {
+  const lines = raw.split("\n");
+  const parts: string[] = [];
+
+  for (const line of lines) {
+    if (!line.startsWith("data: ")) continue;
+    const json = line.slice(6); // strip "data: "
+    if (!json.trim()) continue;
+    try {
+      const parsed = JSON.parse(json);
+
+      // Vercel AI SDK UIMessageStream text delta
+      if (parsed.type === "text-delta" && typeof parsed.delta === "string") {
+        parts.push(parsed.delta);
+      }
+
+      // Also handle the older "0:" text prefix format just in case
+      if (typeof parsed === "string") {
+        parts.push(parsed);
+      }
+    } catch {
+      // Some lines may be non-JSON (e.g. empty keepalive), skip them
+    }
+  }
+
+  // Also handle the "0:text" prefix format used by some AI SDK versions
+  for (const line of lines) {
+    if (line.startsWith("0:")) {
+      try {
+        const text = JSON.parse(line.slice(2));
+        if (typeof text === "string") {
+          parts.push(text);
+        }
+      } catch {
+        // skip
+      }
+    }
+  }
+
+  return parts.join("");
+}
+
+/**
+ * Score a response against the expected facts.
+ *
+ * For "Out-of-Scope" category questions, we check whether the response
+ * correctly identifies the question as out of scope (looking for phrases
+ * like "outside the scope", "can't help with that", "not something I cover",
+ * redirect language, etc.)
+ */
+function scoreResponse(
+  response: string,
+  facts: string[],
+  category: string,
+): FactResult[] {
+  const lowerResponse = response.toLowerCase();
+
+  if (category === "Out-of-Scope / Graceful Fallback") {
+    const outOfScopeIndicators = [
+      "outside the scope",
+      "outside of the scope",
+      "not something i",
+      "can't help with that",
+      "i'm here to help with",
+      "i am here to help with",
+      "not within my scope",
+      "beyond the scope",
+      "not able to help",
+      "town info",
+      "town services",
+      "municipal",
+      "suggest",
+      "recommend checking",
+      "you'd want to check",
+      "consult",
+    ];
+
+    return facts.map((fact) => {
+      const lowerFact = fact.toLowerCase();
+
+      // First try direct substring match
+      if (lowerResponse.includes(lowerFact)) {
+        return { fact, found: true };
+      }
+
+      // For out-of-scope questions, also check if the response shows
+      // awareness that this topic is outside its scope
+      const showsOutOfScope = outOfScopeIndicators.some((indicator) =>
+        lowerResponse.includes(indicator),
+      );
+
+      // If the fact is about being "outside scope" or redirecting, and the
+      // response shows that awareness, count it
+      if (
+        showsOutOfScope &&
+        (lowerFact.includes("outside") ||
+          lowerFact.includes("scope") ||
+          lowerFact.includes("suggest") ||
+          lowerFact.includes("navigator can help"))
+      ) {
+        return { fact, found: true };
+      }
+
+      return { fact, found: false };
+    });
+  }
+
+  // Standard scoring: case-insensitive substring match
+  return facts.map((fact) => ({
+    fact,
+    found: lowerResponse.includes(fact.toLowerCase()),
+  }));
+}
+
+async function sendQuestion(question: string): Promise<{ text: string; timeMs: number }> {
+  const start = Date.now();
+
+  const res = await fetch(API_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      messages: [{ role: "user", content: question }],
+      townId: TOWN_ID,
+    }),
+  });
+
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => "");
+    throw new Error(`API returned ${res.status}: ${errBody}`);
+  }
+
+  const raw = await res.text();
+  const text = parseSSEText(raw);
+  const timeMs = Date.now() - start;
+
+  return { text, timeMs };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const datasetPath = resolve(__dirname, "../docs/golden-test-dataset-verified.json");
+  const dataset: GoldenQuestion[] = JSON.parse(readFileSync(datasetPath, "utf-8"));
+
+  console.log(`\n=== RAG Quality Evaluation ===`);
+  console.log(`Dataset: ${dataset.length} questions`);
+  console.log(`API: ${API_URL}`);
+  console.log(`Town: ${TOWN_ID}\n`);
+
+  const results: QuestionResult[] = [];
+  let passCount = 0;
+
+  for (let i = 0; i < dataset.length; i++) {
+    const q = dataset[i];
+    const label = `[${i + 1}/${dataset.length}] ${q.id}`;
+
+    process.stdout.write(`${label}: "${q.question.slice(0, 60)}..." `);
+
+    let response = "";
+    let timeMs = 0;
+    let error: string | null = null;
+
+    try {
+      const result = await sendQuestion(q.question);
+      response = result.text;
+      timeMs = result.timeMs;
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+      console.log(`ERROR: ${error}`);
+    }
+
+    const facts = scoreResponse(
+      response,
+      q.verified_answer_contains,
+      q.category,
+    );
+    const factsFound = facts.filter((f) => f.found).length;
+    const totalFacts = facts.length;
+    const score = totalFacts > 0 ? factsFound / totalFacts : 0;
+
+    if (score >= 0.5) passCount++;
+
+    results.push({
+      id: q.id,
+      category: q.category,
+      difficulty: q.difficulty,
+      verification_status: q.verification_status,
+      question: q.question,
+      response,
+      facts,
+      facts_found: factsFound,
+      total_facts: totalFacts,
+      score,
+      response_time_ms: timeMs,
+      error,
+    });
+
+    if (!error) {
+      const pct = Math.round(score * 100);
+      const bar = pct >= 75 ? "PASS" : pct >= 50 ? "PARTIAL" : "FAIL";
+      console.log(`${bar} ${pct}% (${factsFound}/${totalFacts} facts) ${timeMs}ms`);
+    }
+
+    // Delay between requests to avoid overwhelming the API
+    if (i < dataset.length - 1) {
+      await sleep(DELAY_MS);
+    }
+  }
+
+  const overallScore =
+    results.reduce((sum, r) => sum + r.score, 0) / results.length;
+
+  console.log(`\n=== Summary ===`);
+  console.log(`Overall Score: ${Math.round(overallScore * 100)}%`);
+  console.log(`Pass (>=50%): ${passCount}/${results.length}`);
+
+  const dateStr = new Date().toISOString().split("T")[0];
+  const outputPath = resolve(__dirname, `../docs/eval-results-${dateStr}.json`);
+
+  const output: EvalResults = {
+    run_date: new Date().toISOString(),
+    api_url: API_URL,
+    town_id: TOWN_ID,
+    total_questions: dataset.length,
+    results,
+  };
+
+  writeFileSync(outputPath, JSON.stringify(output, null, 2));
+  console.log(`\nResults saved to: ${outputPath}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/scripts/eval-scorecard.ts
+++ b/scripts/eval-scorecard.ts
@@ -1,0 +1,375 @@
+/**
+ * RAG Quality Scorecard Generator
+ *
+ * Reads a docs/eval-results-*.json file (most recent by default) and produces
+ * a markdown scorecard at docs/eval-scorecard-YYYY-MM-DD.md.
+ *
+ * Usage:  npx tsx scripts/eval-scorecard.ts [path-to-eval-results.json]
+ */
+
+import { readFileSync, readdirSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+// ---------------------------------------------------------------------------
+// Types (mirrors eval-golden-test.ts output)
+// ---------------------------------------------------------------------------
+
+type FactResult = {
+  fact: string;
+  found: boolean;
+};
+
+type QuestionResult = {
+  id: string;
+  category: string;
+  difficulty: string;
+  verification_status: string;
+  question: string;
+  response: string;
+  facts: FactResult[];
+  facts_found: number;
+  total_facts: number;
+  score: number;
+  response_time_ms: number;
+  error: string | null;
+};
+
+type EvalResults = {
+  run_date: string;
+  api_url: string;
+  town_id: string;
+  total_questions: number;
+  results: QuestionResult[];
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pct(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 !== 0
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+function avg(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function groupBy<T>(items: T[], key: (item: T) => string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const k = key(item);
+    if (!map.has(k)) map.set(k, []);
+    map.get(k)!.push(item);
+  }
+  return map;
+}
+
+function emoji(score: number): string {
+  if (score >= 0.8) return "🟢";
+  if (score >= 0.5) return "🟡";
+  return "🔴";
+}
+
+// ---------------------------------------------------------------------------
+// Find most recent eval results file
+// ---------------------------------------------------------------------------
+
+function findLatestResults(): string {
+  const docsDir = resolve(__dirname, "../docs");
+  const files = readdirSync(docsDir)
+    .filter((f) => f.startsWith("eval-results-") && f.endsWith(".json"))
+    .sort()
+    .reverse();
+
+  if (files.length === 0) {
+    throw new Error(
+      "No eval-results-*.json files found in docs/. Run `npm run eval` first.",
+    );
+  }
+
+  return resolve(docsDir, files[0]);
+}
+
+// ---------------------------------------------------------------------------
+// Build scorecard
+// ---------------------------------------------------------------------------
+
+function buildScorecard(data: EvalResults): string {
+  const { results } = data;
+  const overallScore = avg(results.map((r) => r.score));
+  const totalFacts = results.reduce((s, r) => s + r.total_facts, 0);
+  const totalFound = results.reduce((s, r) => s + r.facts_found, 0);
+  const times = results.filter((r) => !r.error).map((r) => r.response_time_ms);
+  const errors = results.filter((r) => r.error);
+
+  const lines: string[] = [];
+
+  // Header
+  lines.push("# RAG Quality Evaluation Scorecard");
+  lines.push("");
+  lines.push(`**Run Date:** ${data.run_date}`);
+  lines.push(`**API:** ${data.api_url}`);
+  lines.push(`**Town:** ${data.town_id}`);
+  lines.push(`**Questions:** ${data.total_questions}`);
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  // Overall score
+  lines.push("## Overall Score");
+  lines.push("");
+  lines.push(
+    `### ${emoji(overallScore)} ${pct(overallScore)} (${totalFound} / ${totalFacts} facts found)`,
+  );
+  lines.push("");
+
+  const passCount = results.filter((r) => r.score >= 0.5).length;
+  const fullPassCount = results.filter((r) => r.score === 1).length;
+  lines.push(`- **Pass rate (≥50% facts):** ${passCount}/${results.length} (${pct(passCount / results.length)})`);
+  lines.push(`- **Perfect score (100%):** ${fullPassCount}/${results.length} (${pct(fullPassCount / results.length)})`);
+  if (errors.length > 0) {
+    lines.push(`- **Errors:** ${errors.length} questions failed to get a response`);
+  }
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  // Score by category
+  lines.push("## Score by Category");
+  lines.push("");
+  lines.push("| Category | Questions | Avg Score | Facts Found | Pass Rate |");
+  lines.push("|----------|-----------|-----------|-------------|-----------|");
+
+  const byCategory = groupBy(results, (r) => r.category);
+  const sortedCategories = Array.from(byCategory.entries()).sort(
+    (a, b) => avg(a[1].map((r) => r.score)) - avg(b[1].map((r) => r.score)),
+  );
+
+  for (const [category, items] of sortedCategories) {
+    const catScore = avg(items.map((r) => r.score));
+    const catFacts = items.reduce((s, r) => s + r.facts_found, 0);
+    const catTotal = items.reduce((s, r) => s + r.total_facts, 0);
+    const catPass = items.filter((r) => r.score >= 0.5).length;
+    lines.push(
+      `| ${emoji(catScore)} ${category} | ${items.length} | ${pct(catScore)} | ${catFacts}/${catTotal} | ${catPass}/${items.length} |`,
+    );
+  }
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  // Score by difficulty
+  lines.push("## Score by Difficulty");
+  lines.push("");
+  lines.push("| Difficulty | Questions | Avg Score | Pass Rate |");
+  lines.push("|------------|-----------|-----------|-----------|");
+
+  const byDifficulty = groupBy(results, (r) => r.difficulty);
+  for (const diff of ["Easy", "Medium", "Hard"]) {
+    const items = byDifficulty.get(diff) ?? [];
+    if (items.length === 0) continue;
+    const diffScore = avg(items.map((r) => r.score));
+    const diffPass = items.filter((r) => r.score >= 0.5).length;
+    lines.push(
+      `| ${emoji(diffScore)} ${diff} | ${items.length} | ${pct(diffScore)} | ${diffPass}/${items.length} |`,
+    );
+  }
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  // Score by verification status
+  lines.push("## Score by Verification Status");
+  lines.push("");
+  lines.push("| Status | Questions | Avg Score | Pass Rate |");
+  lines.push("|--------|-----------|-----------|-----------|");
+
+  const byStatus = groupBy(results, (r) => r.verification_status);
+  for (const [status, items] of byStatus.entries()) {
+    const statusScore = avg(items.map((r) => r.score));
+    const statusPass = items.filter((r) => r.score >= 0.5).length;
+    lines.push(
+      `| ${emoji(statusScore)} ${status} | ${items.length} | ${pct(statusScore)} | ${statusPass}/${items.length} |`,
+    );
+  }
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  // Top 10 worst questions
+  lines.push("## Top 10 Worst Questions");
+  lines.push("");
+  const worst = [...results].sort((a, b) => a.score - b.score).slice(0, 10);
+
+  for (const r of worst) {
+    const missingFacts = r.facts
+      .filter((f) => !f.found)
+      .map((f) => f.fact);
+    lines.push(`### ${r.id} — ${pct(r.score)} (${r.facts_found}/${r.total_facts})`);
+    lines.push(`**Q:** ${r.question}`);
+    lines.push(`**Category:** ${r.category} | **Difficulty:** ${r.difficulty}`);
+    if (missingFacts.length > 0) {
+      lines.push(`**Missing facts:**`);
+      for (const fact of missingFacts) {
+        lines.push(`- ${fact}`);
+      }
+    }
+    if (r.error) {
+      lines.push(`**Error:** ${r.error}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("---");
+  lines.push("");
+
+  // Top 10 best questions
+  lines.push("## Top 10 Best Questions");
+  lines.push("");
+  const best = [...results].sort((a, b) => b.score - a.score).slice(0, 10);
+
+  for (const r of best) {
+    lines.push(
+      `- ${emoji(r.score)} **${r.id}** — ${pct(r.score)} (${r.facts_found}/${r.total_facts}) — "${r.question.slice(0, 70)}"`,
+    );
+  }
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  // Response time stats
+  lines.push("## Response Time Statistics");
+  lines.push("");
+  if (times.length > 0) {
+    lines.push(`| Metric | Value |`);
+    lines.push(`|--------|-------|`);
+    lines.push(`| Average | ${Math.round(avg(times))}ms |`);
+    lines.push(`| Median (P50) | ${Math.round(median(times))}ms |`);
+    lines.push(`| P95 | ${Math.round(percentile(times, 95))}ms |`);
+    lines.push(`| Slowest | ${Math.round(Math.max(...times))}ms |`);
+    lines.push(`| Fastest | ${Math.round(Math.min(...times))}ms |`);
+  } else {
+    lines.push("No response time data available (all requests errored).");
+  }
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+
+  // Recommendations
+  lines.push("## Recommendations for RAG Improvement");
+  lines.push("");
+
+  // Analyze weak categories
+  const weakCategories = sortedCategories
+    .filter(([, items]) => avg(items.map((r) => r.score)) < 0.5)
+    .map(([cat]) => cat);
+
+  if (weakCategories.length > 0) {
+    lines.push("### Weak Categories (below 50% avg score)");
+    lines.push("");
+    for (const cat of weakCategories) {
+      lines.push(`- **${cat}** — Consider adding more source documents or improving chunk quality for this topic area`);
+    }
+    lines.push("");
+  }
+
+  // Common missing facts
+  const allMissing = results.flatMap((r) =>
+    r.facts.filter((f) => !f.found).map((f) => ({
+      fact: f.fact,
+      category: r.category,
+      id: r.id,
+    })),
+  );
+
+  if (allMissing.length > 0) {
+    lines.push("### Missing Fact Patterns");
+    lines.push("");
+
+    // Group by category to find patterns
+    const missingByCategory = groupBy(allMissing, (m) => m.category);
+    for (const [cat, items] of missingByCategory.entries()) {
+      if (items.length >= 3) {
+        lines.push(`- **${cat}**: ${items.length} missing facts across ${new Set(items.map((i) => i.id)).size} questions`);
+      }
+    }
+    lines.push("");
+  }
+
+  // General recommendations
+  lines.push("### General Recommendations");
+  lines.push("");
+
+  if (overallScore < 0.5) {
+    lines.push("1. **Critical:** Overall score below 50%. Review source document coverage and chunking strategy");
+  }
+
+  const slowP95 = times.length > 0 ? percentile(times, 95) : 0;
+  if (slowP95 > 5000) {
+    lines.push(`1. **Performance:** P95 response time is ${Math.round(slowP95)}ms. Consider optimizing embedding generation or reducing chunk count`);
+  }
+
+  if (errors.length > 0) {
+    lines.push(`1. **Reliability:** ${errors.length} questions returned errors. Investigate API stability`);
+  }
+
+  const hardScore = avg((byDifficulty.get("Hard") ?? []).map((r) => r.score));
+  if (hardScore < 0.4) {
+    lines.push("1. **Hard questions underperforming:** Consider adding more detailed source documents for complex multi-part topics");
+  }
+
+  const partiallyVerified = byStatus.get("partially_verified") ?? [];
+  const pvScore = avg(partiallyVerified.map((r) => r.score));
+  if (partiallyVerified.length > 0 && pvScore < 0.4) {
+    lines.push("1. **Partially-verified questions scoring low:** These questions may need more specific source documents or better chunking");
+  }
+
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  lines.push("*Generated by `npm run eval:scorecard`*");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const inputPath = process.argv[2]
+    ? resolve(process.argv[2])
+    : findLatestResults();
+
+  console.log(`Reading: ${inputPath}`);
+
+  const data: EvalResults = JSON.parse(readFileSync(inputPath, "utf-8"));
+  const scorecard = buildScorecard(data);
+
+  const dateStr = data.run_date.split("T")[0];
+  const outputPath = resolve(__dirname, `../docs/eval-scorecard-${dateStr}.md`);
+
+  writeFileSync(outputPath, scorecard);
+  console.log(`Scorecard written to: ${outputPath}`);
+  console.log(`\nOverall score: ${pct(avg(data.results.map((r) => r.score)))}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- **`scripts/eval-golden-test.ts`** — Reads 73-question golden test dataset, sends each to the Chat API (with 1s delay), parses streaming SSE responses, scores against verified facts via case-insensitive substring matching, and saves results to `docs/eval-results-YYYY-MM-DD.json`
- **`scripts/eval-scorecard.ts`** — Reads eval results and generates a markdown scorecard with overall score, category/difficulty/verification breakdowns, top 10 worst/best questions, response time stats, and RAG improvement recommendations
- **npm scripts** — `npm run eval` and `npm run eval:scorecard`
- **README.md** — Appended RAG Quality Evaluation section documenting the tooling

## Test plan
- [x] `npx tsc --noEmit` passes (zero errors)
- [x] `npm run build` passes (zero errors)
- [x] `npm test` passes (83/83 tests)
- [ ] Run `npm run eval` with dev server to verify end-to-end (manual, not part of CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)