### PR TITLE
Fix duplicate source pills and expand synonym dictionary

### DIFF
--- a/src/lib/rag.ts
+++ b/src/lib/rag.ts
@@ -235,10 +235,12 @@ export function dedupeSources(chunks: RetrievedChunk[]): SourceReference[] {
   for (const chunk of chunks) {
     // Skip sources with generic/meaningless titles
     if (isGenericTitle(chunk.source.documentTitle)) continue;
-    // Dedup by URL first, then by cleaned title
-    const key = chunk.source.documentUrl
-      ? chunk.source.documentUrl
-      : chunk.source.documentTitle;
+
+    // Primary dedup key: cleaned document title (not URL)
+    // This prevents "Frequently Asked Questions" from appearing 3x
+    // when it comes from different CivicPlus URLs
+    const key = chunk.source.documentTitle.toLowerCase().trim();
+
     if (!seen.has(key)) {
       seen.set(key, chunk.source);
     }

--- a/src/lib/synonyms.ts
+++ b/src/lib/synonyms.ts
@@ -156,6 +156,34 @@ const UNIVERSAL_SYNONYMS: SynonymDictionary = [
     triggers: ["pothole", "road repair"],
     expansions: ["DPW", "public works", "highway department"],
   },
+  {
+    triggers: ["pool", "swimming", "swim lessons"],
+    expansions: ["swimming pool", "aquatics", "recreation"],
+  },
+  {
+    triggers: ["adu", "in-law apartment", "in-law suite", "granny flat", "guest house"],
+    expansions: ["accessory dwelling unit", "ADU", "zoning bylaw"],
+  },
+  {
+    triggers: ["food truck", "catering"],
+    expansions: ["mobile food vendor", "board of health", "food establishment"],
+  },
+  {
+    triggers: ["compost", "yard waste", "leaves", "leaf pickup"],
+    expansions: ["transfer station", "DPW", "yard waste disposal"],
+  },
+  {
+    triggers: ["property tax rate", "mill rate", "tax rate"],
+    expansions: ["assessor", "tax rate", "residential tax rate"],
+  },
+  {
+    triggers: ["curbside pickup", "trash pickup", "garbage pickup"],
+    expansions: ["transfer station", "no curbside", "pay as you throw", "PAYT"],
+  },
+  {
+    triggers: ["parking ticket", "parking fine"],
+    expansions: ["parking clerk", "town clerk"],
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -199,6 +227,34 @@ const TOWN_SYNONYMS: Record<string, SynonymDictionary> = {
     {
       triggers: ["sticker", "transfer station sticker"],
       expansions: ["RTS sticker", "transfer station permit", "annual sticker"],
+    },
+    {
+      triggers: ["rosemary pool", "the pool"],
+      expansions: ["Rosemary Recreation Complex", "swimming pool", "aquatics"],
+    },
+    {
+      triggers: ["payt", "pay as you throw", "trash bags"],
+      expansions: ["Pay-As-You-Throw", "PAYT bags", "transfer station"],
+    },
+    {
+      triggers: ["high rock", "pollard"],
+      expansions: ["High Rock School", "Pollard Middle School", "middle school"],
+    },
+    {
+      triggers: ["broadmeadow", "eliot", "mitchell", "sunita williams", "newman"],
+      expansions: ["elementary school", "Needham Public Schools"],
+    },
+    {
+      triggers: ["katie king"],
+      expansions: ["Town Manager", "Select Board"],
+    },
+    {
+      triggers: ["dan walsh"],
+      expansions: ["Building Inspector", "Building Department"],
+    },
+    {
+      triggers: ["needham line", "commuter rail"],
+      expansions: ["MBTA Needham Line", "Needham Heights station", "Needham Junction station", "Needham Center station", "South Station"],
     },
   ],
 };


### PR DESCRIPTION
## Summary
- **Source pill dedup**: Changed `dedupeSources()` to key on cleaned document title instead of URL, preventing generic CivicPlus titles (e.g. "Frequently Asked Questions") from appearing 3+ times as source links
- **Synonym expansion**: Added 14 new synonym entries (7 universal, 7 Needham-specific) identified during golden test dataset research — covers pool/swimming, ADU, food trucks, compost, PAYT, school names, town officials, and commuter rail

## Test plan
- [ ] Ask a FAQ-heavy question and verify only one "Frequently Asked Questions" source pill appears
- [ ] Try queries like "Rosemary Pool", "PAYT", "Katie King" and confirm expanded results
- [ ] Verify no regressions in normal chat quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)