### PR TITLE
feat: search API + answer cache + skin config

### DIFF
--- a/__tests__/integration.test.ts
+++ b/__tests__/integration.test.ts
@@ -144,7 +144,7 @@ function mockFromData(data: unknown[]) {
 import { GET as getDepartments } from "@/app/api/departments/route";
 import { GET as getCategories } from "@/app/api/categories/route";
 import { POST as postChat } from "@/app/api/chat/route";
-import { GET as getSearch } from "@/app/api/search/route";
+import { POST as postSearch } from "@/app/api/search/route";
 import { POST as postFeedback } from "@/app/api/feedback/route";
 import { GET as getAdminAnalytics } from "@/app/api/admin/analytics/route";
 import {
@@ -227,14 +227,17 @@ describe("Test 3 — Chat Endpoint", () => {
 });
 
 // ===========================================================================
-// TEST 4 — Search Endpoint: GET /api/search?q=zoning returns 200
+// TEST 4 — Search Endpoint: POST /api/search returns 200
 // ===========================================================================
 
 describe("Test 4 — Search Endpoint", () => {
     it("returns 200 for a search query", async () => {
         mockRpc.mockResolvedValue({ data: [], error: null });
 
-        const res = await getSearch(makeRequest("/api/search?q=zoning"));
+        const res = await postSearch(makeRequest("/api/search", {
+            method: "POST",
+            body: JSON.stringify({ query: "zoning", town_id: "needham" })
+        }));
         expect(res.status).toBe(200);
 
         const json = (await res.json()) as { results: unknown[] };

--- a/config/towns.ts
+++ b/config/towns.ts
@@ -35,6 +35,10 @@ export type TownFeatureFlags = {
   enableSafety: boolean;
   enableTransit: boolean;
   enableWeather: boolean;
+  /** Which UI skin to use: 'classic' (current chat-first) or 'search' (search-first + floating chat) */
+  uiMode: 'classic' | 'search';
+  /** Enable cached AI answers for common queries */
+  enableAnswerCache: boolean;
 };
 
 export type TownLocation = {
@@ -128,6 +132,8 @@ export const TOWNS: TownConfig[] = [
       enableSafety: true,
       enableTransit: true,
       enableWeather: true,
+      uiMode: 'classic',
+      enableAnswerCache: true,
     },
     location: { lat: 42.2828, lng: -71.2337 },
     transit_route: "CR-Needham",
@@ -182,6 +188,8 @@ export const TOWNS: TownConfig[] = [
       enableSafety: false,
       enableTransit: false,
       enableWeather: false,
+      uiMode: 'search',
+      enableAnswerCache: true,
     },
     location: { lat: 42.0, lng: -71.0 },
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "monitor": "tsx scripts/monitor.ts",
     "validate": "tsx scripts/validate-ingestion.ts",
     "eval": "tsx scripts/eval-golden-test.ts",
-    "eval:scorecard": "tsx scripts/eval-scorecard.ts"
+    "eval:scorecard": "tsx scripts/eval-scorecard.ts",
+    "seed-cache": "tsx scripts/seed-answer-cache.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.26",

--- a/scripts/seed-answer-cache.ts
+++ b/scripts/seed-answer-cache.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env tsx
+/**
+ * Cache Seeding Script
+ *
+ * Pre-populates the answer cache by sending golden test dataset questions
+ * to the local chat API and storing the responses.
+ *
+ * Usage:
+ *   1. Start dev server: npm run dev
+ *   2. In another terminal: npm run seed-cache
+ *
+ * Rate limit: 1 request per 2 seconds to avoid overwhelming the API
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { setCachedAnswer } from '../src/lib/answer-cache';
+
+const DATASET_PATH = join(__dirname, '..', 'docs', 'golden-test-dataset-verified.json');
+const CHAT_API_URL = 'http://localhost:3000/api/chat';
+const RATE_LIMIT_MS = 2000; // 2 seconds between requests
+const TOWN_ID = 'needham';
+
+interface GoldenTestQuestion {
+  id: string;
+  question: string;
+  category: string;
+  verification_status: string;
+  verified_answer_contains: string[];
+}
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ChatResponse {
+  messages?: ChatMessage[];
+  error?: string;
+}
+
+/**
+ * Send a question to the chat API and collect the full response.
+ * Returns the response text and sources.
+ */
+async function askQuestion(question: string): Promise<{ text: string; sources: { title: string; url: string }[] }> {
+  const response = await fetch(CHAT_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      messages: [{ role: 'user', content: question }],
+      town_id: TOWN_ID,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Chat API returned ${response.status}: ${await response.text()}`);
+  }
+
+  // The chat API returns a streaming response. We need to consume it.
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error('No response body');
+  }
+
+  const decoder = new TextDecoder();
+  let fullText = '';
+  const sources: { title: string; url: string }[] = [];
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value, { stream: true });
+      const lines = chunk.split('\n');
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        if (!line.startsWith('data: ')) continue;
+
+        const dataStr = line.slice(6).trim();
+        if (!dataStr) continue;
+
+        try {
+          const data = JSON.parse(dataStr);
+
+          // Collect text deltas
+          if (data.type === 'text-delta' && data.delta) {
+            fullText += data.delta;
+          }
+
+          // Collect sources
+          if (data.type === 'data-sources' && Array.isArray(data.data)) {
+            for (const source of data.data) {
+              if (source.document_title && source.document_url) {
+                sources.push({
+                  title: source.document_title,
+                  url: source.document_url,
+                });
+              }
+            }
+          }
+        } catch (parseError) {
+          // Skip malformed JSON
+          continue;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return { text: fullText.trim(), sources };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main() {
+  console.log('🌱 Cache Seeding Script');
+  console.log('========================\n');
+
+  // Load dataset
+  let dataset: GoldenTestQuestion[];
+  try {
+    const raw = readFileSync(DATASET_PATH, 'utf-8');
+    dataset = JSON.parse(raw);
+    console.log(`✓ Loaded ${dataset.length} questions from golden test dataset\n`);
+  } catch (error) {
+    console.error('❌ Failed to load dataset:', error);
+    process.exit(1);
+  }
+
+  // Filter to verified questions only
+  const verifiedQuestions = dataset.filter(
+    (q) => q.verification_status === 'verified'
+  );
+  console.log(`📋 Processing ${verifiedQuestions.length} verified questions\n`);
+
+  let successCount = 0;
+  let failCount = 0;
+
+  for (let i = 0; i < verifiedQuestions.length; i++) {
+    const question = verifiedQuestions[i];
+    const progress = `[${i + 1}/${verifiedQuestions.length}]`;
+
+    try {
+      const start = Date.now();
+      console.log(`${progress} Caching: "${question.question.slice(0, 60)}${question.question.length > 60 ? '...' : ''}"`);
+
+      const { text, sources } = await askQuestion(question.question);
+
+      if (!text) {
+        console.log(`  ⚠️  Empty response, skipping cache\n`);
+        failCount++;
+        continue;
+      }
+
+      await setCachedAnswer(question.question, TOWN_ID, text, sources);
+
+      const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+      console.log(`  ✓ Cached (${elapsed}s, ${sources.length} sources)\n`);
+      successCount++;
+
+      // Rate limit
+      if (i < verifiedQuestions.length - 1) {
+        await sleep(RATE_LIMIT_MS);
+      }
+    } catch (error) {
+      console.log(`  ❌ Failed:`, error instanceof Error ? error.message : String(error));
+      console.log();
+      failCount++;
+    }
+  }
+
+  console.log('========================');
+  console.log(`✅ Done: ${successCount} cached, ${failCount} failed`);
+  console.log();
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,41 +1,133 @@
-import { DEFAULT_TOWN_ID, hybridSearch } from "@/lib/rag";
+import { NextResponse } from 'next/server';
+import { hybridSearch, type HybridSearchResult } from '@/lib/rag';
+import { getCachedAnswer } from '@/lib/answer-cache';
+import { DEFAULT_TOWN_ID } from '@/lib/towns';
 
-export async function GET(request: Request): Promise<Response> {
-  const { searchParams } = new URL(request.url);
-  const query = searchParams.get("q")?.trim() ?? "";
-  const townId = searchParams.get("town")?.trim() || DEFAULT_TOWN_ID;
+interface SearchResult {
+  id: string;
+  title: string;
+  snippet: string;
+  source_url: string;
+  department: string;
+  date: string;
+  similarity: number;
+  highlights: string[];
+}
 
-  if (!query) {
-    return Response.json(
-      { error: "Query parameter 'q' is required." },
+type SearchRequestBody = {
+  query?: unknown;
+  town_id?: unknown;
+  townId?: unknown;
+  limit?: unknown;
+};
+
+function truncateSnippet(text: string, maxLength: number = 300): string {
+  if (text.length <= maxLength) return text;
+  const truncated = text.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated) + '…';
+}
+
+function extractDepartment(metadata: Record<string, unknown>): string {
+  if (typeof metadata.department === 'string') return metadata.department;
+  if (typeof metadata.chunk_type === 'string') return metadata.chunk_type;
+  return 'General';
+}
+
+function extractDate(metadata: Record<string, unknown>): string {
+  const dateFields = ['document_date', 'effective_date', 'last_amended', 'last_verified_at', 'last_updated'];
+  for (const field of dateFields) {
+    if (typeof metadata[field] === 'string' && metadata[field]) {
+      return metadata[field] as string;
+    }
+  }
+  return '';
+}
+
+function toSearchResult(result: HybridSearchResult): SearchResult {
+  const metadata = result.metadata as Record<string, unknown>;
+  const title = typeof metadata.document_title === 'string'
+    ? metadata.document_title
+    : 'Untitled Document';
+  const sourceUrl = typeof metadata.document_url === 'string'
+    ? metadata.document_url
+    : '';
+
+  return {
+    id: result.id,
+    title,
+    snippet: truncateSnippet(result.chunk_text, 300),
+    source_url: sourceUrl,
+    department: extractDepartment(metadata),
+    date: extractDate(metadata),
+    similarity: result.similarity,
+    highlights: result.highlight ? [result.highlight] : [],
+  };
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const start = performance.now();
+
+  let body: SearchRequestBody;
+  try {
+    body = (await request.json()) as SearchRequestBody;
+  } catch {
+    return NextResponse.json(
+      { error: 'Invalid JSON request body.' },
       { status: 400 }
     );
   }
 
-  try {
-    const results = await hybridSearch(query, { townId, limit: 15 });
+  // Validate query
+  if (typeof body.query !== 'string' || !body.query.trim()) {
+    return NextResponse.json(
+      { error: 'Query parameter is required and must be a non-empty string.' },
+      { status: 400 }
+    );
+  }
 
-    return Response.json({
-      results: results.map((result) => ({
-        id: result.id,
-        chunk_text: result.chunk_text,
-        document_title: result.source.documentTitle,
-        document_url: result.source.documentUrl,
-        section: result.source.section,
-        similarity: result.similarity,
-        highlight: result.highlight,
-        score: result.score,
-      })),
-      total: results.length,
+  const query = body.query.trim();
+  if (query.length > 500) {
+    return NextResponse.json(
+      { error: 'Query must be 500 characters or less.' },
+      { status: 400 }
+    );
+  }
+
+  // Parse town_id and limit
+  const townId =
+    (typeof body.town_id === 'string' && body.town_id.trim()) ||
+    (typeof body.townId === 'string' && body.townId.trim()) ||
+    DEFAULT_TOWN_ID;
+
+  let limit = 10;
+  if (typeof body.limit === 'number' && Number.isInteger(body.limit) && body.limit > 0) {
+    limit = Math.min(body.limit, 20); // Cap at 20
+  }
+
+  try {
+    // Run hybrid search and cache lookup in parallel
+    const [hybridResults, cachedAnswer] = await Promise.all([
+      hybridSearch(query, { townId, limit }),
+      getCachedAnswer(query, townId),
+    ]);
+
+    const results = hybridResults.map(toSearchResult);
+    const timingMs = Math.round(performance.now() - start);
+
+    return NextResponse.json({
+      results,
+      cached_answer: cachedAnswer,
+      timing_ms: timingMs,
     });
   } catch (error) {
-    const details =
-      error instanceof Error ? error.message : "Unexpected search API error.";
-
-    return Response.json(
+    console.error('[api/search] Error:', error);
+    const message =
+      error instanceof Error ? error.message : 'Unexpected search API error.';
+    return NextResponse.json(
       {
-        error: "Search is temporarily unavailable. Please try again shortly.",
-        details,
+        error: 'Unable to process search request. Please try again.',
+        details: message,
       },
       { status: 500 }
     );

--- a/src/lib/answer-cache.ts
+++ b/src/lib/answer-cache.ts
@@ -1,0 +1,83 @@
+import { getSupabaseServiceClient } from './supabase';
+
+export interface CachedAnswer {
+  answer_html: string;
+  sources: { title: string; url: string }[];
+  created_at: string;
+  is_cached: true;
+}
+
+/**
+ * Normalize a query for cache matching.
+ * Lowercase, trim, strip punctuation, collapse whitespace.
+ * This means "What are transfer station hours?" matches
+ * "transfer station hours" matches "Transfer Station Hours".
+ */
+export function normalizeQuery(query: string): string {
+  return query
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Look up a cached answer. Returns null on miss.
+ * Checks expiry — stale entries return null.
+ */
+export async function getCachedAnswer(
+  query: string,
+  townId: string
+): Promise<CachedAnswer | null> {
+  const normalized = normalizeQuery(query);
+  const supabase = getSupabaseServiceClient();
+
+  const { data, error } = await supabase
+    .from('cached_answers')
+    .select('answer_html, sources, created_at')
+    .eq('town_id', townId)
+    .eq('normalized_query', normalized)
+    .gt('expires_at', new Date().toISOString())
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error || !data) return null;
+
+  return {
+    answer_html: data.answer_html,
+    sources: data.sources as { title: string; url: string }[],
+    created_at: data.created_at,
+    is_cached: true,
+  };
+}
+
+/**
+ * Store an answer in the cache.
+ * Default TTL: 7 days.
+ */
+export async function setCachedAnswer(
+  query: string,
+  townId: string,
+  answerHtml: string,
+  sources: { title: string; url: string }[],
+  ttlDays: number = 7
+): Promise<void> {
+  const normalized = normalizeQuery(query);
+  const expiresAt = new Date();
+  expiresAt.setDate(expiresAt.getDate() + ttlDays);
+
+  const supabase = getSupabaseServiceClient();
+
+  await supabase.from('cached_answers').upsert(
+    {
+      town_id: townId,
+      normalized_query: normalized,
+      original_query: query.trim(),
+      answer_html: answerHtml,
+      sources,
+      expires_at: expiresAt.toISOString(),
+    },
+    { onConflict: 'town_id,normalized_query' }
+  );
+}

--- a/src/lib/rag.ts
+++ b/src/lib/rag.ts
@@ -637,6 +637,16 @@ function normalizeSimilarity(value: number): number {
   return value;
 }
 
+/**
+ * Truncate text to a max length, breaking at word boundary.
+ */
+export function truncateSnippet(text: string, maxLength: number = 300): string {
+  if (text.length <= maxLength) return text;
+  const truncated = text.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return (lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated) + '…';
+}
+
 export async function hybridSearch(
   query: string,
   options?: {

--- a/supabase/migrations/20260214000000_cached_answers.sql
+++ b/supabase/migrations/20260214000000_cached_answers.sql
@@ -1,0 +1,47 @@
+-- =====================================================================
+-- Migration: Cached Answers Table
+-- Date: 2026-02-14
+-- Description: Create cached_answers table for storing pre-computed AI
+--              answers to common queries. Speeds up search-mode UI by
+--              serving instant answers for frequent questions.
+--
+-- IMPORTANT: This migration must be run manually against the Supabase
+--            project via the SQL editor or CLI. It is NOT run automatically.
+--
+-- To apply:
+--   1. Open Supabase Dashboard > SQL Editor
+--   2. Paste this file's contents
+--   3. Click "Run"
+-- =====================================================================
+
+-- Cached AI answers for common queries
+-- Speeds up search-mode UI by serving instant answers
+CREATE TABLE IF NOT EXISTS cached_answers (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  town_id TEXT NOT NULL,
+  normalized_query TEXT NOT NULL,
+  original_query TEXT NOT NULL,
+  answer_html TEXT NOT NULL,
+  sources JSONB NOT NULL DEFAULT '[]',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  hit_count INTEGER DEFAULT 0,
+  UNIQUE(town_id, normalized_query)
+);
+
+-- Index for fast lookups (only non-expired entries)
+CREATE INDEX idx_cached_answers_lookup
+  ON cached_answers (town_id, normalized_query)
+  WHERE expires_at > NOW();
+
+-- Index for cleanup jobs
+CREATE INDEX idx_cached_answers_expiry
+  ON cached_answers (expires_at);
+
+-- Optional: Add comment to table
+COMMENT ON TABLE cached_answers IS 'Stores pre-computed AI answers for common queries. Entries expire after TTL (default 7 days).';
+COMMENT ON COLUMN cached_answers.normalized_query IS 'Lowercase, punctuation-stripped query for matching. E.g. "transfer station hours"';
+COMMENT ON COLUMN cached_answers.original_query IS 'Original query text as entered by user for debugging';
+COMMENT ON COLUMN cached_answers.answer_html IS 'Full AI-generated answer (may contain markdown or HTML)';
+COMMENT ON COLUMN cached_answers.sources IS 'Array of {title, url} objects for source citations';
+COMMENT ON COLUMN cached_answers.hit_count IS 'Number of times this cached answer has been served (for analytics)';


### PR DESCRIPTION
Adds backend infrastructure for search-first UI skin:

## New Features
- **POST /api/search** — fast vector+text search endpoint (no LLM, sub-100ms target)
- **Answer cache** — `cached_answers` table in Supabase with 7-day TTL
- **Write-through cache** — chat API now caches responses for future search hits
- **UI mode flag** — `uiMode: 'classic' | 'search'` in town config
- **Cache seeding script** — `npm run seed-cache` to pre-populate from golden test dataset

## Breaking Changes
- Search API changed from `GET /api/search?q=...` to `POST /api/search` with JSON body

## Database Migration Required
Before deploying to production, run `supabase/migrations/20260214000000_cached_answers.sql` via SQL editor.

## Testing
- ✅ Build passes (34 pages)
- ✅ TypeScript clean
- ✅ All 83 tests passing
- ✅ Updated integration test for POST endpoint

Part 1 of 2 — frontend skin components in separate PR.