### PR TITLE
feat: upgrade eval scoring to LLM-as-judge

### DIFF
--- a/scripts/eval-golden-test.ts
+++ b/scripts/eval-golden-test.ts
@@ -2,16 +2,32 @@
  * RAG Quality Evaluation — Golden Test Runner
  *
  * Reads docs/golden-test-dataset-verified.json, sends each question to the
- * local Chat API, scores the response against verified_answer_contains via
- * case-insensitive substring matching, and writes results to
- * docs/eval-results-YYYY-MM-DD.json.
+ * local Chat API, scores the response using LLM-as-judge (semantic matching),
+ * and writes results to docs/eval-results-YYYY-MM-DD.json.
  *
  * Usage:  npx tsx scripts/eval-golden-test.ts
- * Requires:  dev server running at http://localhost:3000
+ * Requires:  server running at http://localhost:3000, OPENAI_API_KEY set
  */
 
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync, existsSync } from "fs";
 import { resolve } from "path";
+import OpenAI from "openai";
+
+// Load .env.local (Next.js doesn't do this for standalone scripts)
+const envPath = resolve(__dirname, "../.env.local");
+if (existsSync(envPath)) {
+  for (const line of readFileSync(envPath, "utf-8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim();
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,6 +49,7 @@ type GoldenQuestion = {
 type FactResult = {
   fact: string;
   found: boolean;
+  method: "llm-judge" | "substring";
 };
 
 type QuestionResult = {
@@ -54,6 +71,7 @@ type EvalResults = {
   run_date: string;
   api_url: string;
   town_id: string;
+  scoring_method: string;
   total_questions: number;
   results: QuestionResult[];
 };
@@ -64,7 +82,27 @@ type EvalResults = {
 
 const API_URL = "http://localhost:3000/api/chat";
 const TOWN_ID = "needham";
-const DELAY_MS = 1000;
+const DELAY_MS = 3000;
+const MAX_RETRIES = 3;
+const RETRY_BASE_MS = 5000;
+const JUDGE_MODEL = "gpt-4.1-nano";
+
+// ---------------------------------------------------------------------------
+// OpenAI client for LLM-as-judge
+// ---------------------------------------------------------------------------
+
+let openai: OpenAI | null = null;
+
+function getOpenAI(): OpenAI {
+  if (!openai) {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error("Missing OPENAI_API_KEY — needed for LLM-as-judge scoring");
+    }
+    openai = new OpenAI({ apiKey });
+  }
+  return openai;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -76,11 +114,6 @@ function sleep(ms: number): Promise<void> {
 
 /**
  * Parse a UIMessageStream SSE response and extract the concatenated text.
- *
- * The stream sends lines like:
- *   data: {"type":"text-delta","id":"...","delta":"some text"}
- *
- * We accumulate all text-delta payloads.
  */
 function parseSSEText(raw: string): string {
   const lines = raw.split("\n");
@@ -88,26 +121,22 @@ function parseSSEText(raw: string): string {
 
   for (const line of lines) {
     if (!line.startsWith("data: ")) continue;
-    const json = line.slice(6); // strip "data: "
+    const json = line.slice(6);
     if (!json.trim()) continue;
     try {
       const parsed = JSON.parse(json);
-
-      // Vercel AI SDK UIMessageStream text delta
       if (parsed.type === "text-delta" && typeof parsed.delta === "string") {
         parts.push(parsed.delta);
       }
-
-      // Also handle the older "0:" text prefix format just in case
       if (typeof parsed === "string") {
         parts.push(parsed);
       }
     } catch {
-      // Some lines may be non-JSON (e.g. empty keepalive), skip them
+      // skip non-JSON lines
     }
   }
 
-  // Also handle the "0:text" prefix format used by some AI SDK versions
+  // Also handle "0:text" prefix format
   for (const line of lines) {
     if (line.startsWith("0:")) {
       try {
@@ -124,100 +153,127 @@ function parseSSEText(raw: string): string {
   return parts.join("");
 }
 
+// ---------------------------------------------------------------------------
+// LLM-as-Judge scoring
+// ---------------------------------------------------------------------------
+
 /**
- * Score a response against the expected facts.
- *
- * For "Out-of-Scope" category questions, we check whether the response
- * correctly identifies the question as out of scope (looking for phrases
- * like "outside the scope", "can't help with that", "not something I cover",
- * redirect language, etc.)
+ * Use a cheap LLM to judge whether a response contains a given fact.
+ * Handles paraphrasing, different formatting, semantic equivalence.
+ * Batches all facts for a single response into one API call for efficiency.
  */
-function scoreResponse(
+async function judgeFactsBatch(
+  question: string,
   response: string,
   facts: string[],
-  category: string,
-): FactResult[] {
-  const lowerResponse = response.toLowerCase();
-
-  if (category === "Out-of-Scope / Graceful Fallback") {
-    const outOfScopeIndicators = [
-      "outside the scope",
-      "outside of the scope",
-      "not something i",
-      "can't help with that",
-      "i'm here to help with",
-      "i am here to help with",
-      "not within my scope",
-      "beyond the scope",
-      "not able to help",
-      "town info",
-      "town services",
-      "municipal",
-      "suggest",
-      "recommend checking",
-      "you'd want to check",
-      "consult",
-    ];
-
-    return facts.map((fact) => {
-      const lowerFact = fact.toLowerCase();
-
-      // First try direct substring match
-      if (lowerResponse.includes(lowerFact)) {
-        return { fact, found: true };
-      }
-
-      // For out-of-scope questions, also check if the response shows
-      // awareness that this topic is outside its scope
-      const showsOutOfScope = outOfScopeIndicators.some((indicator) =>
-        lowerResponse.includes(indicator),
-      );
-
-      // If the fact is about being "outside scope" or redirecting, and the
-      // response shows that awareness, count it
-      if (
-        showsOutOfScope &&
-        (lowerFact.includes("outside") ||
-          lowerFact.includes("scope") ||
-          lowerFact.includes("suggest") ||
-          lowerFact.includes("navigator can help"))
-      ) {
-        return { fact, found: true };
-      }
-
-      return { fact, found: false };
-    });
+): Promise<FactResult[]> {
+  if (!response.trim()) {
+    return facts.map((fact) => ({ fact, found: false, method: "llm-judge" as const }));
   }
 
-  // Standard scoring: case-insensitive substring match
-  return facts.map((fact) => ({
-    fact,
-    found: lowerResponse.includes(fact.toLowerCase()),
-  }));
+  const factsListText = facts
+    .map((f, i) => `${i + 1}. ${f}`)
+    .join("\n");
+
+  const prompt = `You are evaluating whether an AI assistant's response contains specific facts. The response may paraphrase, reformat, or reword the facts — that's fine. What matters is whether the INFORMATION is present, not the exact wording.
+
+QUESTION asked: "${question}"
+
+AI RESPONSE:
+"""
+${response}
+"""
+
+EXPECTED FACTS (check each one):
+${factsListText}
+
+For each fact, respond with ONLY "YES" or "NO" — one per line, in order. YES means the response contains or conveys that information (even if worded differently, uses different punctuation, different number format, lists items separately vs grouped, etc.). NO means the information is absent or contradicted.
+
+Example output for 3 facts:
+YES
+NO
+YES`;
+
+  try {
+    const client = getOpenAI();
+    const completion = await client.chat.completions.create({
+      model: JUDGE_MODEL,
+      messages: [{ role: "user", content: prompt }],
+      temperature: 0,
+      max_tokens: facts.length * 4 + 20,
+    });
+
+    const judgeResponse = completion.choices[0]?.message?.content ?? "";
+    const verdicts = judgeResponse
+      .split("\n")
+      .map((line) => line.trim().toUpperCase())
+      .filter((line) => line === "YES" || line === "NO");
+
+    return facts.map((fact, i) => ({
+      fact,
+      found: verdicts[i] === "YES",
+      method: "llm-judge" as const,
+    }));
+  } catch (e) {
+    // If judge fails, fall back to substring matching
+    console.log(`\n    [judge fallback: ${e instanceof Error ? e.message : String(e)}]`);
+    return facts.map((fact) => ({
+      fact,
+      found: response.toLowerCase().includes(fact.toLowerCase()),
+      method: "substring" as const,
+    }));
+  }
 }
 
+// ---------------------------------------------------------------------------
+// Chat API caller with retries
+// ---------------------------------------------------------------------------
+
 async function sendQuestion(question: string): Promise<{ text: string; timeMs: number }> {
-  const start = Date.now();
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (attempt > 0) {
+      const backoff = RETRY_BASE_MS * Math.pow(2, attempt - 1);
+      process.stdout.write(`\n    retry ${attempt}/${MAX_RETRIES} after ${backoff / 1000}s... `);
+      await sleep(backoff);
+    }
 
-  const res = await fetch(API_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      messages: [{ role: "user", content: question }],
-      townId: TOWN_ID,
-    }),
-  });
+    const start = Date.now();
+    try {
+      const res = await fetch(API_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: question }],
+          townId: TOWN_ID,
+        }),
+        signal: AbortSignal.timeout(120_000),
+      });
 
-  if (!res.ok) {
-    const errBody = await res.text().catch(() => "");
-    throw new Error(`API returned ${res.status}: ${errBody}`);
+      if (!res.ok) {
+        const errBody = await res.text().catch(() => "");
+        if (res.status >= 500 && attempt < MAX_RETRIES) continue;
+        throw new Error(`API returned ${res.status}: ${errBody.slice(0, 200)}`);
+      }
+
+      const raw = await res.text();
+      const text = parseSSEText(raw);
+      const timeMs = Date.now() - start;
+      return { text, timeMs };
+    } catch (e) {
+      if (attempt >= MAX_RETRIES) throw e;
+      const msg = e instanceof Error ? e.message : String(e);
+      if (
+        msg.includes("fetch failed") ||
+        msg.includes("terminated") ||
+        msg.includes("ECONNREFUSED") ||
+        msg.includes("timeout")
+      ) {
+        continue;
+      }
+      throw e;
+    }
   }
-
-  const raw = await res.text();
-  const text = parseSSEText(raw);
-  const timeMs = Date.now() - start;
-
-  return { text, timeMs };
+  throw new Error("Exhausted all retries");
 }
 
 // ---------------------------------------------------------------------------
@@ -228,10 +284,14 @@ async function main() {
   const datasetPath = resolve(__dirname, "../docs/golden-test-dataset-verified.json");
   const dataset: GoldenQuestion[] = JSON.parse(readFileSync(datasetPath, "utf-8"));
 
-  console.log(`\n=== RAG Quality Evaluation ===`);
+  // Verify OpenAI key is set for LLM-as-judge
+  getOpenAI();
+
+  console.log(`\n=== RAG Quality Evaluation (LLM-as-Judge) ===`);
   console.log(`Dataset: ${dataset.length} questions`);
   console.log(`API: ${API_URL}`);
-  console.log(`Town: ${TOWN_ID}\n`);
+  console.log(`Town: ${TOWN_ID}`);
+  console.log(`Judge model: ${JUDGE_MODEL}\n`);
 
   const results: QuestionResult[] = [];
   let passCount = 0;
@@ -255,11 +315,18 @@ async function main() {
       console.log(`ERROR: ${error}`);
     }
 
-    const facts = scoreResponse(
-      response,
-      q.verified_answer_contains,
-      q.category,
-    );
+    // Score using LLM-as-judge
+    let facts: FactResult[];
+    if (error || !response.trim()) {
+      facts = q.verified_answer_contains.map((fact) => ({
+        fact,
+        found: false,
+        method: "substring" as const,
+      }));
+    } else {
+      facts = await judgeFactsBatch(q.question, response, q.verified_answer_contains);
+    }
+
     const factsFound = facts.filter((f) => f.found).length;
     const totalFacts = facts.length;
     const score = totalFacts > 0 ? factsFound / totalFacts : 0;
@@ -287,7 +354,23 @@ async function main() {
       console.log(`${bar} ${pct}% (${factsFound}/${totalFacts} facts) ${timeMs}ms`);
     }
 
-    // Delay between requests to avoid overwhelming the API
+    // Save progress every 10 questions (in case of crash)
+    if ((i + 1) % 10 === 0 || i === dataset.length - 1) {
+      const partialOutput: EvalResults = {
+        run_date: new Date().toISOString(),
+        api_url: API_URL,
+        town_id: TOWN_ID,
+        scoring_method: `llm-as-judge (${JUDGE_MODEL})`,
+        total_questions: dataset.length,
+        results,
+      };
+      const dateStr = new Date().toISOString().split("T")[0];
+      const progressPath = resolve(__dirname, `../docs/eval-results-${dateStr}.json`);
+      writeFileSync(progressPath, JSON.stringify(partialOutput, null, 2));
+      console.log(`  [saved progress: ${results.length}/${dataset.length}]`);
+    }
+
+    // Delay between requests
     if (i < dataset.length - 1) {
       await sleep(DELAY_MS);
     }
@@ -307,6 +390,7 @@ async function main() {
     run_date: new Date().toISOString(),
     api_url: API_URL,
     town_id: TOWN_ID,
+    scoring_method: `llm-as-judge (${JUDGE_MODEL})`,
     total_questions: dataset.length,
     results,
   };


### PR DESCRIPTION
## Summary
- Replace substring matching with OpenAI gpt-4.1-nano semantic judge for accurate fact verification
- Add retry logic with exponential backoff (3 retries at 5/10/20s) for server stability
- Add .env.local loader since standalone tsx scripts don't get Next.js env loading
- Save progress every 10 questions to prevent data loss on crash
- Increase inter-request delay to 3s and add 120s timeout per request

**Impact:** Same eval responses scored 4% with substring matching → 42% with LLM-as-judge. The old scorer penalized paraphrasing, different punctuation, and reformatted lists.

## Test plan
- [ ] Run `npm run eval` against local server — verify LLM-as-judge scoring produces results
- [ ] Run `npm run eval:scorecard` — verify scorecard generates correctly
- [ ] Confirm `npx tsc --noEmit` passes (already verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)