### PR TITLE
feat: switch Needham to search-first UI skin

### DIFF
--- a/config/towns.ts
+++ b/config/towns.ts
@@ -132,7 +132,7 @@ export const TOWNS: TownConfig[] = [
       enableSafety: true,
       enableTransit: true,
       enableWeather: true,
-      uiMode: 'classic',
+      uiMode: 'search',
       enableAnswerCache: true,
     },
     location: { lat: 42.2828, lng: -71.2337 },


### PR DESCRIPTION
Flips Needham's `uiMode` from `'classic'` to `'search'` to make the search-first UI the default production experience.

## What Changed
- **File:** `config/towns.ts` (line 135)
- **Change:** `uiMode: 'classic'` → `uiMode: 'search'`

## UI Features
The search-first skin provides:
- Search hero with "Search Needham" prompt
- Topic chips for quick navigation (Permits, Events, etc.)
- Browse cards for different departments
- Floating chat FAB (bottom-right) for conversational Q&A

## Backward Compatibility
The classic chat-first UI remains available at `/needham/chat`.

## Reverting
Can be reverted by changing `uiMode` back to `'classic'` (or via admin panel once the skin toggle ships).

## Testing
- ✅ Build passes
- ✅ All tests pass (83/83)
- ✅ TypeScript check passes
- ✅ UI verified in browser at http://localhost:3001/needham