### PR TITLE
feat: floating chat overhaul with expanded mode and scroll fix

### DIFF
--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -27,6 +27,7 @@ export function ChatBubble({ message, onFollowupClick, sessionId }: ChatBubblePr
         className="flex gap-2.5 justify-start animate-msg-in"
         role="status"
         aria-live="polite"
+        data-message-id={message.id}
       >
         <div className="w-[30px] h-[30px] rounded-full bg-gradient-to-br from-primary to-primary-light flex items-center justify-center text-white text-xs font-extrabold shrink-0 mt-0.5">
           N
@@ -40,7 +41,7 @@ export function ChatBubble({ message, onFollowupClick, sessionId }: ChatBubblePr
 
   if (message.role === "user") {
     return (
-      <div className="flex justify-end animate-msg-in">
+      <div className="flex justify-end animate-msg-in" data-message-id={message.id}>
         <div className="max-w-[90%] sm:max-w-[80%] bg-primary text-white px-[18px] py-3.5 rounded-2xl rounded-br-md text-[14.5px] leading-relaxed">
           {message.text}
         </div>
@@ -50,7 +51,7 @@ export function ChatBubble({ message, onFollowupClick, sessionId }: ChatBubblePr
 
   // AI message
   return (
-    <div className="flex gap-2.5 justify-start animate-msg-in">
+    <div className="flex gap-2.5 justify-start animate-msg-in" data-message-id={message.id}>
       <div className="w-[30px] h-[30px] rounded-full bg-gradient-to-br from-primary to-primary-light flex items-center justify-center text-white text-xs font-extrabold shrink-0 mt-0.5">
         N
       </div>


### PR DESCRIPTION
## Summary
- **Fix scroll position:** AI responses now scroll to show the TOP of the response, not the bottom — long responses are readable from the start without manual scrolling
- **Add expanded/fullscreen mode:** Toggle button in header switches between compact (400px bottom-right) and expanded (near-fullscreen with backdrop overlay). Mobile gets true fullscreen.
- **Send full conversation history:** Chat now has multi-turn memory — follow-up questions can reference prior exchanges
- **Improved empty state:** Friendly greeting "👋 Hi! I'm your Needham AI assistant..." with suggestion chips
- **Better typing indicator:** Shows "Needham AI is thinking..." text alongside animated dots
- **More generous padding in expanded mode:** px-8 py-6 for ChatGPT mobile-style breathing room

## Technical Details
- Added `isExpanded` state + `Maximize2`/`Minimize2` toggle icons
- Replaced `scrollToBottom` with `scrollToLatestAiMessage` using `data-message-id` targeting and `scrollIntoView({ block: 'start' })`
- Conversation history filters out "typing" messages and maps "ai" → "assistant" role
- Backdrop overlay (`bg-black/30 z-40`) dims page behind expanded chat
- Responsive: compact on desktop, expanded adapts to screen size, mobile is fullscreen

## Files Changed
- `src/components/search/FloatingChat.tsx` — Main overhaul (scroll, expanded mode, conversation context, padding)
- `src/components/ChatBubble.tsx` — Added `data-message-id` attributes for scroll targeting

## Test Plan
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npm test`)
- [x] Type check passes (`npx tsc --noEmit`)
- [x] Scroll fix: long AI response shows top of message, not bottom
- [x] Expanded mode: near-fullscreen with backdrop, collapse back to compact
- [x] Mobile: expanded mode is truly fullscreen
- [x] Conversation context: follow-up questions reference prior messages
- [x] Empty state: greeting + suggestion chips render properly
- [x] Padding: more breathing room in expanded mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)