### PR TITLE
fix: correct chat API request format in health check

### DIFF
--- a/.github/workflows/nightly-health-check.yml
+++ b/.github/workflows/nightly-health-check.yml
@@ -44,7 +44,7 @@ jobs:
             # Single curl call captures both body and HTTP code
             RAW_RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" --max-time 60 -X POST "https://www.needhamnavigator.com/api/chat" \
               -H "Content-Type: application/json" \
-              -d '{"message":"What are the hours for Needham Town Hall?","townId":"needham"}' 2>/dev/null || echo "HTTP_CODE:000")
+              -d '{"messages":[{"role":"user","content":"What are the hours for Needham Town Hall?"}],"townId":"needham"}' 2>/dev/null || echo "HTTP_CODE:000")
 
             API_HTTP=$(echo "$RAW_RESPONSE" | grep -o 'HTTP_CODE:[0-9]*' | tail -1 | cut -d: -f2)
             API_BODY=$(echo "$RAW_RESPONSE" | sed '/HTTP_CODE:[0-9]*/d')


### PR DESCRIPTION
## Summary
Fixes the production health check failure by correcting the chat API request format.

## The Problem
The nightly health check was failing with HTTP 400 error: `"Request must include at least one message."`

The health check was sending:
```json
{"message": "What are the hours for Needham Town Hall?", "townId": "needham"}
```

But the chat API expects:
```json
{"messages": [{"role": "user", "content": "What are the hours..."}], "townId": "needham"}
```

## Changes
- Updated `.github/workflows/nightly-health-check.yml` line 47
- Changed `message` (singular string) to `messages` (array of message objects)
- Added proper message structure with `role` and `content` fields

## Test Plan
- [x] Build passes locally
- [x] Type check passes
- [x] Tested chat API locally with curl using new format
- [x] API returns valid streaming response with confidence, sources, and answer

Fixes #35