### PR TITLE
fix: search results deduplication, relevance filtering, always-on AI answers, title cleanup

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from 'next/server';
-import { hybridSearch, type HybridSearchResult } from '@/lib/rag';
+import { hybridSearch, type HybridSearchResult, cleanDocumentTitle } from '@/lib/rag';
 import { getCachedAnswer } from '@/lib/answer-cache';
 import { DEFAULT_TOWN_ID } from '@/lib/towns';
+import { stripMarkdown } from '@/lib/utils';
+
+// Import the same threshold used in the chat RAG pipeline
+const MIN_SIMILARITY_THRESHOLD = 0.3;
 
 interface SearchResult {
   id: string;
@@ -46,23 +50,50 @@ function extractDate(metadata: Record<string, unknown>): string {
 
 function toSearchResult(result: HybridSearchResult): SearchResult {
   const metadata = result.metadata as Record<string, unknown>;
-  const title = typeof metadata.document_title === 'string'
+  const rawTitle = typeof metadata.document_title === 'string'
     ? metadata.document_title
     : 'Untitled Document';
+  const title = cleanDocumentTitle(rawTitle);
   const sourceUrl = typeof metadata.document_url === 'string'
     ? metadata.document_url
     : '';
 
+  // Strip markdown from snippet before truncating
+  const cleanedSnippet = stripMarkdown(result.chunk_text);
+
   return {
     id: result.id,
     title,
-    snippet: truncateSnippet(result.chunk_text, 300),
+    snippet: truncateSnippet(cleanedSnippet, 300),
     source_url: sourceUrl,
     department: extractDepartment(metadata),
     date: extractDate(metadata),
     similarity: result.similarity,
     highlights: result.highlight ? [result.highlight] : [],
   };
+}
+
+/**
+ * Deduplicate search results by source URL.
+ * For each unique URL, keeps only the result with the highest similarity score.
+ */
+function deduplicateByUrl(results: SearchResult[]): SearchResult[] {
+  const bestByUrl = new Map<string, SearchResult>();
+
+  for (const result of results) {
+    // Skip results without a source URL
+    if (!result.source_url) {
+      continue;
+    }
+
+    const existing = bestByUrl.get(result.source_url);
+    if (!existing || result.similarity > existing.similarity) {
+      bestByUrl.set(result.source_url, result);
+    }
+  }
+
+  // Return deduplicated results sorted by similarity (highest first)
+  return Array.from(bestByUrl.values()).sort((a, b) => b.similarity - a.similarity);
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -108,11 +139,22 @@ export async function POST(request: Request): Promise<Response> {
   try {
     // Run hybrid search and cache lookup in parallel
     const [hybridResults, cachedAnswer] = await Promise.all([
-      hybridSearch(query, { townId, limit }),
+      hybridSearch(query, { townId, limit: limit * 3 }), // Retrieve more for deduplication
       getCachedAnswer(query, townId),
     ]);
 
-    const results = hybridResults.map(toSearchResult);
+    // Convert to search results
+    let results = hybridResults.map(toSearchResult);
+
+    // Apply similarity threshold filter (same as chat RAG pipeline)
+    results = results.filter(r => r.similarity >= MIN_SIMILARITY_THRESHOLD);
+
+    // Deduplicate by source URL (keep highest-scoring chunk per page)
+    results = deduplicateByUrl(results);
+
+    // Limit to requested count after deduplication
+    results = results.slice(0, limit);
+
     const timingMs = Math.round(performance.now() - start);
 
     return NextResponse.json({

--- a/src/components/SearchHomePage.tsx
+++ b/src/components/SearchHomePage.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Search, Trash2, Building2, School, DollarSign, Bus, Sparkles } from "lucide-react";
+import { Search, Trash2, Building2, School, DollarSign, Bus } from "lucide-react";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { SearchResultCard } from "@/components/search/SearchResultCard";
@@ -67,7 +67,7 @@ type AIAnswerState =
   | { type: "loading" }
   | { type: "cached"; answer: CachedAnswer }
   | { type: "loaded"; html: string; sources: { title: string; url: string }[] }
-  | { type: "prompt" };
+  | { type: "error"; message: string };
 
 function normalizeQuery(value: string | null): string {
   return (value ?? "").trim();
@@ -143,8 +143,78 @@ export function SearchHomePage() {
           return;
         }
 
-        // 3. No auto-generation - always show opt-in prompt
-        setAiAnswer({ type: "prompt" });
+        // 3. Always generate AI answer for uncached queries
+        if (data.results.length > 0) {
+          // Only generate if we have results
+          setAiAnswer({ type: "loading" });
+
+          try {
+            const chatRes = await fetch("/api/chat", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                messages: [{ role: "user", content: q }],
+                town_id: town.town_id,
+              }),
+            });
+
+            if (!chatRes.ok) {
+              throw new Error("Failed to generate AI answer");
+            }
+
+            // Parse the streaming response
+            const reader = chatRes.body?.getReader();
+            if (!reader) {
+              throw new Error("No response body");
+            }
+
+            let answerHtml = "";
+            let sources: { title: string; url: string }[] = [];
+            const decoder = new TextDecoder();
+
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+
+              const chunk = decoder.decode(value);
+              const lines = chunk.split("\n");
+
+              for (const line of lines) {
+                if (!line.startsWith("data: ")) continue;
+                const data = line.slice(6).trim();
+                if (!data || data === "[DONE]") continue;
+
+                try {
+                  const parsed = JSON.parse(data);
+
+                  // Handle text deltas
+                  if (parsed.type === "text-delta") {
+                    answerHtml += parsed.delta;
+                  }
+
+                  // Handle sources
+                  if (parsed.type === "data-sources") {
+                    sources = parsed.data.map((s: { document_title: string; document_url?: string }) => ({
+                      title: s.document_title,
+                      url: s.document_url ?? "",
+                    }));
+                  }
+                } catch {
+                  // Skip malformed JSON
+                }
+              }
+            }
+
+            if (answerHtml) {
+              setAiAnswer({ type: "loaded", html: answerHtml, sources });
+            } else {
+              setAiAnswer({ type: "error", message: "No answer generated" });
+            }
+          } catch (error) {
+            console.error("AI answer generation error:", error);
+            setAiAnswer({ type: "error", message: "Failed to generate AI answer" });
+          }
+        }
 
         if (data.results.length === 0) {
           trackEvent('search_no_results', {
@@ -373,26 +443,7 @@ export function SearchHomePage() {
               </div>
             )}
 
-            {/* AI Answer Prompt Banner (compact) */}
-            {aiAnswer.type === "prompt" && (
-              <div className="bg-[#F0F9FF] border border-[#BAE6FF] rounded-lg px-4 py-3 mb-4 flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Sparkles size={16} className="text-[var(--primary)]" />
-                  <span className="text-[14px] text-text-primary">
-                    Want an AI-powered answer?
-                  </span>
-                </div>
-                <button
-                  onClick={() => chatRef.current?.openWithMessage(query)}
-                  className="px-3 py-1.5 bg-[var(--primary)] text-white text-[13px] font-medium rounded-md hover:bg-[var(--primary-dark)] transition-colors"
-                  data-pendo="ask-ai-banner"
-                >
-                  Ask AI
-                </button>
-              </div>
-            )}
-
-            {/* AI Answer (if cached or loaded) */}
+            {/* AI Answer (loading, cached, loaded, or error) */}
             {aiAnswer.type === "loading" && <AIAnswerCard state="loading" />}
             {aiAnswer.type === "cached" && (
               <AIAnswerCard
@@ -408,6 +459,11 @@ export function SearchHomePage() {
                 sources={aiAnswer.sources}
                 onFollowUp={handleFollowUp}
               />
+            )}
+            {aiAnswer.type === "error" && (
+              <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 mb-4 text-[14px] text-red-700">
+                Failed to generate AI answer. Try asking in chat instead.
+              </div>
             )}
 
             {/* Result cards */}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,17 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Strip markdown formatting from text to display clean snippets.
+ * Removes headers, bold, italic, code, and links.
+ */
+export function stripMarkdown(text: string): string {
+  return text
+    .replace(/#{1,6}\s*/g, '')        // headers
+    .replace(/\*\*(.*?)\*\*/g, '$1')  // bold
+    .replace(/\*(.*?)\*/g, '$1')      // italic
+    .replace(/`(.*?)`/g, '$1')        // inline code
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1') // links
+    .trim();
+}


### PR DESCRIPTION
## Summary
- Deduplicates search results by source URL — each page appears once with its best-matching chunk
- Applies similarity threshold to filter irrelevant results (reuses 0.3 threshold from RAG pipeline)
- Always generates an AI answer for search queries — removes inconsistent 'Ask AI' prompt
- Strips CivicPlus CMS suffixes from page titles (e.g. '- CivicPlus.CMS.FAQ')
- Strips raw markdown from search result snippets
- Cleans up match percentage display

## Test Plan
- Search 'building permits' → no duplicate results, AI answer present
- Search 'recycling' → no duplicate FAQ results, clean titles (no CivicPlus suffix), AI answer present
- Search 'snow plowing' → no irrelevant results (no Aquifer Protection), AI answer present
- Search 'school enrollment' → graceful handling even with no data
- Verify no raw markdown in any search result snippets
- Run \`npx next build\` to verify no build errors ✅

## Issues Addressed
P0 issues #1-4 from production testing (Feb 15, 2026):
1. ✅ Duplicate results from same source page
2. ✅ Irrelevant results surfacing with high match scores
3. ✅ Inconsistent AI Answer generation
4. ✅ Raw CMS page titles in results