### PR TITLE
fix: search results show AI summaries, hide match %, polish badges and buttons

### DIFF
--- a/src/components/search/SearchResultCard.tsx
+++ b/src/components/search/SearchResultCard.tsx
@@ -25,27 +25,32 @@ function generateAskQuestion(title: string): string {
   return `Tell me more about ${cleaned.toLowerCase()}`;
 }
 
-export function SearchResultCard({ result, onAskAbout, "data-pendo": dataPendo }: SearchResultCardProps) {
-  const similarityPercent = Math.round(result.similarity * 100);
+/**
+ * Format department name for display (proper capitalization)
+ */
+function formatDepartment(dept: string): string {
+  return dept
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+}
 
-  // Determine similarity color
-  const similarityColor =
-    result.similarity >= 0.8
-      ? "text-success"
-      : result.similarity >= 0.6
-      ? "text-[#0891B2]"
-      : "text-text-muted";
+export function SearchResultCard({ result, onAskAbout, "data-pendo": dataPendo }: SearchResultCardProps) {
+  // Prefer AI-generated title over raw title
+  const displayTitle = result.ai_title || result.title;
+
+  // Prefer AI-generated summary over raw snippet
+  const displaySnippet = result.ai_summary || result.snippet;
 
   // Extract domain from URL for Google-style display
   const displayUrl = result.source_url ? new URL(result.source_url).hostname + new URL(result.source_url).pathname : '';
 
   return (
     <div className="group pb-4" data-pendo={dataPendo}>
-      {/* Department tag */}
-      <div className="flex items-center gap-1.5 mb-1">
-        <span className="inline-block w-1.5 h-1.5 rounded-full bg-[#0891B2]" />
-        <span className="text-[11px] uppercase tracking-wider font-medium text-[#0891B2]">
-          {result.department}
+      {/* Department badge - polished pill style */}
+      <div className="mb-1.5">
+        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-medium bg-blue-50 text-blue-700 border border-blue-100">
+          {formatDepartment(result.department)}
         </span>
       </div>
 
@@ -65,11 +70,11 @@ export function SearchResultCard({ result, onAskAbout, "data-pendo": dataPendo }
           }}
           className="text-[18px] font-normal text-[var(--primary)] hover:underline leading-snug block mb-1"
         >
-          {result.title}
+          {displayTitle}
         </a>
       ) : (
         <h3 className="text-[18px] font-normal text-[var(--primary)] leading-snug mb-1">
-          {result.title}
+          {displayTitle}
         </h3>
       )}
 
@@ -80,34 +85,43 @@ export function SearchResultCard({ result, onAskAbout, "data-pendo": dataPendo }
         </div>
       )}
 
-      {/* Snippet with highlights */}
+      {/* Snippet/Summary - prefer AI summary for cleaner display */}
       <div
         className="text-[14px] text-text-secondary leading-relaxed line-clamp-3 mb-2 [&_mark]:bg-[var(--accent-light)] [&_mark]:text-text-primary [&_mark]:font-medium [&_mark]:px-0.5"
-        dangerouslySetInnerHTML={{ __html: result.snippet }}
+        dangerouslySetInnerHTML={{ __html: displaySnippet }}
       />
 
+      {/* AI Tags (if present) */}
+      {result.ai_tags && result.ai_tags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-2">
+          {result.ai_tags.slice(0, 4).map((tag, idx) => (
+            <span
+              key={idx}
+              className="inline-block px-2 py-0.5 text-[11px] bg-gray-50 text-gray-600 rounded border border-gray-200"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
       {/* Bottom row: metadata + actions */}
-      <div className="flex items-center gap-3 flex-wrap text-[12px] text-text-muted">
+      <div className="flex items-center gap-3 flex-wrap text-[12px]">
         {/* Date */}
-        {result.date && <span>{result.date}</span>}
+        {result.date && <span className="text-text-muted">{result.date}</span>}
 
-        {/* Similarity */}
-        <span className={`font-medium ${similarityColor}`}>
-          {similarityPercent}% match
-        </span>
-
-        {/* Ask about this button */}
+        {/* Ask about this button - polished with clear affordance */}
         <button
           onClick={() => {
             trackEvent('result_ask_about_clicked', {
               title: result.title,
               department: result.department,
             });
-            onAskAbout(generateAskQuestion(result.title));
+            onAskAbout(generateAskQuestion(displayTitle));
           }}
-          className="inline-flex items-center gap-1 text-[var(--primary)] hover:underline"
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-white border border-[var(--primary)]/30 text-[var(--primary)] hover:bg-[var(--primary)]/5 hover:border-[var(--primary)] transition-all font-medium"
         >
-          <MessageSquare size={12} />
+          <MessageSquare size={14} />
           Ask about this
         </button>
       </div>

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -7,6 +7,9 @@ export interface SearchResult {
   date: string;
   similarity: number;
   highlights: string[];
+  ai_title?: string;
+  ai_summary?: string;
+  ai_tags?: string[];
 }
 
 export interface CachedAnswer {


### PR DESCRIPTION
## Summary
Search results now display AI-enriched data instead of raw chunk text, with polished UI components for better user experience.

### Changes Made
- ✅ Search results prefer `ai_title` over raw title (removes CMS suffixes like "- Town of Needham, MA | CivicEngage")
- ✅ Search results prefer `ai_summary` over raw snippet (clean 2-3 sentence summaries instead of fragmented chunks)
- ✅ Match percentages removed from user-facing results (no more confusing "72% match" text)
- ✅ Department badges styled as pills with proper capitalization ("Public Works" not "PUBLIC_WORKS")
- ✅ "Ask about this" button upgraded with border, background, hover state, and clear affordance
- ✅ AI tags displayed as small pills below summaries (up to 4, only when available)

### Technical Details
- Added `ai_title`, `ai_summary`, and `ai_tags` optional fields to `SearchResult` type
- Updated `SearchResultCard` component to use AI-enriched data with fallbacks
- All data already available from API (added in PR #43) - this PR makes the frontend use it

## Test Plan
✅ Lint passed (zero warnings)
✅ TypeScript check passed
✅ Production build successful
✅ All 83 tests passing
✅ Manually tested search results:
  - Titles are clean (no CMS suffixes)
  - Summaries read like proper sentences, not fragments
  - No match percentages visible
  - Department badges properly styled
  - "Ask about this" button looks clickable with hover effect

## Before/After
**Before:** Search results showed raw chunk text (ugly, truncated mid-sentence, full of address fragments) and confusing "72% match" percentages

**After:** Search results show AI-generated clean summaries, polished badges, and professional button styling

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)