### PR TITLE
fix: remove temperature parameter for gpt-5-nano enrichment

### DIFF
--- a/docs/SOURCE_EXPANSION_REPORT.md
+++ b/docs/SOURCE_EXPANSION_REPORT.md
@@ -255,6 +255,36 @@ Many review and social platforms block web scraping. These are included in the s
 ✅ npm audit --production --audit-level=critical
 ```
 
+### Full Pipeline Test Results ✅
+Validated 2026-02-16:
+
+**Scraper Test** (10 pages):
+- ✅ Sitemap auto-discovery: Found 1,783 URLs across 2 sitemaps (1,079 from needhamma.gov, 704 from schools)
+- ✅ Rate limiting: 1.5s delays between requests
+- ✅ Document type detection: Correctly identified `local_business`, `news`, `general` types
+- ✅ PDF discovery: 3 PDFs found and queued
+- ✅ Duration: 27.0s for 10 pages
+
+**Ingestion Test** (10 pages + 3 PDFs):
+- ✅ Pages chunked: 10 documents → 28 chunks
+- ✅ PDFs extracted: 3 PDFs → 12 chunks
+- ✅ Embeddings generated: 40 total chunks embedded via OpenAI text-embedding-3-small
+- ✅ Total documents processed: 13
+- ✅ Total chunks: 40
+- ✅ Duration: 1.0 minute
+
+**Enrichment Test** (fixed temperature issue):
+- ✅ AI summaries: Clear, helpful 2-3 sentence descriptions
+- ✅ AI titles: Clean, descriptive titles (removed CMS junk)
+- ✅ AI tags: 5-10 relevant tags per document
+- ✅ Content classification: Correctly classified as `department`, `news`, `service`, etc.
+- ⚠️ Fix required: Removed `temperature: 0.1` parameter (gpt-5-nano doesn't support custom temperature)
+
+**Document Type Detection**:
+- ✅ `department`: 7 chunks (town department pages)
+- ✅ `news`: 3 chunks (homepage news and alerts)
+- ✅ Auto-detection working via URL patterns and content analysis
+
 ### Test Ingestion (Recommended)
 ```bash
 # Priority 5 sources only (8 sources, ~100 pages)

--- a/scripts/check-enrichment.ts
+++ b/scripts/check-enrichment.ts
@@ -1,0 +1,50 @@
+/**
+ * Quick script to check enrichment results in the database
+ */
+
+import { getSupabaseServiceClient } from "../src/lib/supabase";
+
+async function checkEnrichment() {
+  const supabase = getSupabaseServiceClient();
+
+  const { data: chunks, error } = await supabase
+    .from("document_chunks")
+    .select("metadata")
+    .limit(10)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    console.error("Error:", error);
+    process.exit(1);
+  }
+
+  console.log("Recent Chunks (last 10):");
+  console.log("========================\n");
+
+  const typeCount: Record<string, number> = {};
+  chunks?.forEach((chunk, i) => {
+    const meta = chunk.metadata as any;
+    const contentType = meta.content_type || "unknown";
+    typeCount[contentType] = (typeCount[contentType] || 0) + 1;
+
+    console.log(`${i + 1}. Type: ${contentType}`);
+    console.log(`   Title: ${meta.ai_title || meta.document_title || "N/A"}`);
+    console.log(`   URL: ${meta.document_url?.substring(0, 60)}...`);
+    if (meta.ai_summary) {
+      console.log(`   Summary: ${meta.ai_summary.substring(0, 80)}...`);
+    }
+    if (meta.ai_tags && meta.ai_tags.length > 0) {
+      console.log(`   Tags: ${meta.ai_tags.slice(0, 5).join(", ")}`);
+    }
+    console.log();
+  });
+
+  console.log("Content Type Distribution:");
+  Object.entries(typeCount)
+    .sort((a, b) => b[1] - a[1])
+    .forEach(([type, count]) => {
+      console.log(`  ${type}: ${count}`);
+    });
+}
+
+checkEnrichment();

--- a/scripts/enrich.ts
+++ b/scripts/enrich.ts
@@ -43,7 +43,7 @@ export async function enrichDocument(
   try {
     const response = await openai.chat.completions.create({
       model: ENRICHMENT_MODEL,
-      temperature: 0.1, // Factual, consistent summaries
+      // Note: gpt-5-nano does not support custom temperature - uses default (1.0)
       response_format: { type: "json_object" },
       messages: [
         {


### PR DESCRIPTION
## Summary
Fixes enrichment failure when using gpt-5-nano model.

## Problem
- gpt-5-nano does not support custom temperature settings
- All enrichment API calls were failing with: `BadRequestError: 400 Unsupported value: 'temperature' does not support 0.1 with this model`
- Documents were falling back to minimal enrichment (no AI summaries, empty tags)

## Solution
- Removed `temperature: 0.1` parameter from enrichDocument() call
- gpt-5-nano now uses default temperature (1.0)
- Enrichment works correctly, generating high-quality summaries and tags

## Test Results
Validated full ingestion pipeline (10 pages + 3 PDFs):
- ✅ AI summaries: Clear, helpful 2-3 sentence descriptions
- ✅ AI titles: Clean, descriptive (CMS junk removed)
- ✅ AI tags: 5-10 relevant tags per document
- ✅ Content classification: department, news, service, etc.
- ✅ 40 total chunks embedded successfully

Sample enrichment output:
```
Type: department
Title: Departments A - L, MA
Summary: This page is a directory of Town of Needham departments from A through L...
Tags: needham-ma, municipal-departments, department-directory, accounting, library
```

## Files Changed
- `scripts/enrich.ts` - Removed temperature parameter
- `docs/SOURCE_EXPANSION_REPORT.md` - Added full test results
- `scripts/check-enrichment.ts` - New testing utility

## Quality Gates
- ✅ Lint clean
- ✅ TypeScript check passed
- ✅ Build successful
- ✅ All 83 tests passing