### PR TITLE
fix: auto-close stale ci-failure issues when PR eventually succeeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,33 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
+            const prTitle = context.payload.pull_request.title;
+
+            // Close any stale ci-failure issues for this PR
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'ci-failure',
+              state: 'open'
+            });
+
+            for (const issue of issues.data) {
+              // Check if this issue is for this PR (title contains PR number or title)
+              if (issue.title.includes(`CI Failure: ${prTitle}`) || issue.body.includes(`#${prNumber}`)) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed'
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `✅ CI eventually passed and PR #${prNumber} was merged. Closing this stale failure issue.`
+                });
+              }
+            }
 
             // Add a success comment
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Problem
When a PR fails CI, the workflow creates a `ci-failure` issue for tracking. However, if the PR is fixed and eventually succeeds/merges, those issues remain open forever.

**Example:** PR #69 had 3 failed CI runs that created issues #71 and #72. Even though PR #69 eventually passed and merged successfully, those issues stayed open as stale noise.

## Solution
Added cleanup logic to the `auto-merge` job that runs when a PR passes CI:

1. **Search** for all open `ci-failure` issues
2. **Match** them to the current PR by checking if the issue title/body references this PR
3. **Close** matched issues with a success comment before merging the PR

## Changes
- **File:** `.github/workflows/ci.yml`
- **Lines:** 64-88 (new cleanup block in auto-merge job)

## Test Plan
- ✅ Build passes: `npm run build`
- ✅ Lint passes: `npm run lint`  
- ✅ Type check passes: `npx tsc --noEmit`
- ✅ Tests pass (integration tests skip in CI as expected)
- ✅ Security audit clean: `npm audit --production --audit-level=critical`

**Validation:** After this PR merges, future PRs that fail then succeed will automatically clean up their stale issues.

## Impact
- Prevents accumulation of stale `ci-failure` issues
- Issues now properly auto-close when their associated PR eventually succeeds
- Reduces manual cleanup work