### PR TITLE
fix: root-path navigation + expand article generation coverage

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,8 +16,13 @@ const nextConfig = {
           has: [{ type: "host", value: NEEDHAM_HOSTS }],
         },
         {
-          source: "/:path(chat|permits|news|search)",
+          source: "/:path(chat|permits|news|search|articles|daily-brief|about)",
           destination: "/needham/:path",
+          has: [{ type: "host", value: NEEDHAM_HOSTS }],
+        },
+        {
+          source: "/:path(articles|chat)/:subpath*",
+          destination: "/needham/:path/:subpath*",
           has: [{ type: "host", value: NEEDHAM_HOSTS }],
         },
       ],

--- a/scripts/check-available-docs.ts
+++ b/scripts/check-available-docs.ts
@@ -1,0 +1,52 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const key = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_ANON_KEY || '';
+const supabase = createClient(url, key);
+
+async function main() {
+  // Count all documents
+  const { data: docs, error } = await supabase
+    .from('documents')
+    .select('id, url, title, created_at, last_ingested_at')
+    .order('last_ingested_at', { ascending: false });
+
+  if (error) {
+    console.error('Error:', error);
+    process.exit(1);
+  }
+
+  console.log(`Total documents: ${docs?.length ?? 0}\n`);
+
+  // Count documents with chunks (that have actual content)
+  const { data: chunked } = await supabase
+    .from('documents')
+    .select('id, url, document_chunks(id)')
+    .not('document_chunks', 'is', null);
+
+  const withChunks = (chunked ?? []).filter(d => (d.document_chunks as unknown[])?.length > 0);
+  console.log(`Documents with chunks: ${withChunks.length}\n`);
+
+  // Check existing article source URLs to see what's already covered
+  const { data: articles } = await supabase
+    .from('articles')
+    .select('source_urls');
+
+  const coveredUrls = new Set<string>();
+  for (const a of articles ?? []) {
+    for (const u of a.source_urls ?? []) {
+      coveredUrls.add(u);
+    }
+  }
+  console.log(`URLs already covered by articles: ${coveredUrls.size}\n`);
+
+  // Show sample of uncovered document URLs
+  const uncovered = (docs ?? []).filter(d => !coveredUrls.has(d.url));
+  console.log(`Uncovered documents: ${uncovered.length}\n`);
+  console.log('Sample uncovered URLs:');
+  for (const d of uncovered.slice(0, 30)) {
+    console.log(`  ${d.url}`);
+  }
+}
+
+void main();

--- a/scripts/debug-docs.ts
+++ b/scripts/debug-docs.ts
@@ -1,0 +1,69 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const key = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_ANON_KEY || '';
+const supabase = createClient(url, key);
+
+async function main() {
+  // Check what columns exist by fetching 1 row
+  const { data: sample, error: sampleErr } = await supabase
+    .from('documents')
+    .select('*')
+    .limit(1)
+    .single();
+
+  if (sampleErr) {
+    console.error('Error fetching sample:', sampleErr);
+  } else {
+    console.log('Document columns:', Object.keys(sample));
+    console.log('Sample document:', JSON.stringify(sample, null, 2));
+  }
+
+  // Try querying with town_id filter
+  const { data: withTown, error: townErr, count: townCount } = await supabase
+    .from('documents')
+    .select('id', { count: 'exact' })
+    .eq('town_id', 'needham')
+    .limit(1);
+
+  console.log(`\nDocuments with town_id='needham': ${townCount ?? withTown?.length ?? 0}`);
+  if (townErr) console.log('Town query error:', townErr);
+
+  // Try without town_id filter
+  const { count: totalCount } = await supabase
+    .from('documents')
+    .select('id', { count: 'exact' })
+    .limit(1);
+
+  console.log(`Total documents (no filter): ${totalCount}`);
+
+  // Check last_ingested_at range
+  const { data: dateRange } = await supabase
+    .from('documents')
+    .select('last_ingested_at')
+    .order('last_ingested_at', { ascending: true })
+    .limit(1);
+
+  const { data: dateRangeMax } = await supabase
+    .from('documents')
+    .select('last_ingested_at')
+    .order('last_ingested_at', { ascending: false })
+    .limit(1);
+
+  console.log(`\nOldest last_ingested_at: ${dateRange?.[0]?.last_ingested_at}`);
+  console.log(`Newest last_ingested_at: ${dateRangeMax?.[0]?.last_ingested_at}`);
+
+  // Check 365-day cutoff
+  const since = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString();
+  console.log(`\n365-day cutoff: ${since}`);
+
+  const { count: matchCount } = await supabase
+    .from('documents')
+    .select('id', { count: 'exact' })
+    .gte('last_ingested_at', since)
+    .limit(1);
+
+  console.log(`Documents within 365 days: ${matchCount}`);
+}
+
+void main();

--- a/scripts/generate-articles-bulk.ts
+++ b/scripts/generate-articles-bulk.ts
@@ -1,0 +1,52 @@
+/**
+ * Bulk article generation — generates articles from ALL categorizable ingested
+ * documents, not just the last 30 days. Use this for initial content seeding
+ * or backfill.
+ *
+ * Usage: npx tsx --env-file=.env.local scripts/generate-articles-bulk.ts
+ */
+
+import {
+  generateFromAllDocuments,
+  generateDailyBrief,
+} from '../src/lib/article-generator';
+
+const DAYS_BACK = 365; // Look at ALL documents from the past year
+
+async function main() {
+  console.log('🗞️  Needham Navigator — Bulk Article Generation\n');
+  console.log(`Looking back ${DAYS_BACK} days for uncovered documents...\n`);
+
+  let generated = 0;
+  let skipped = 0;
+
+  try {
+    console.log('📰 Generating from all categorizable documents...');
+    const articles = await generateFromAllDocuments({ daysBack: DAYS_BACK });
+    console.log(`   ✅ ${articles.length} articles generated\n`);
+    generated += articles.length;
+
+    console.log('📅 Generating daily brief...');
+    const brief = await generateDailyBrief();
+    if (brief) {
+      console.log(`   ✅ Daily brief generated: "${brief.title}"\n`);
+      generated += 1;
+    } else {
+      console.log('   ℹ️  Skipped (already exists or no new content)\n');
+      skipped += 1;
+    }
+  } catch (error) {
+    console.error('❌ Error during generation:', error);
+    process.exit(1);
+  }
+
+  console.log('════════════════════════════════════════');
+  console.log('📊 Bulk Generation Summary');
+  console.log('════════════════════════════════════════');
+  console.log(`✅ Generated:  ${generated} articles`);
+  console.log(`⏭️  Skipped:   ${skipped}`);
+
+  process.exit(0);
+}
+
+void main();

--- a/scripts/list-all-articles.ts
+++ b/scripts/list-all-articles.ts
@@ -1,0 +1,29 @@
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+const key = process.env.SUPABASE_SERVICE_KEY || process.env.SUPABASE_ANON_KEY || '';
+const supabase = createClient(url, key);
+
+async function main() {
+  const { data, error } = await supabase
+    .from('articles')
+    .select('id, title, content_type, category, status, is_daily_brief, published_at, source_urls')
+    .order('published_at', { ascending: false });
+
+  if (error) {
+    console.error('Error:', error);
+    process.exit(1);
+  }
+
+  console.log(`Total articles: ${data?.length ?? 0}\n`);
+  for (const a of data ?? []) {
+    const urls = a.source_urls?.length ?? 0;
+    console.log(`[${a.status}] ${a.is_daily_brief ? '📅 ' : '📰 '}${a.title}`);
+    console.log(`  id: ${a.id}`);
+    console.log(`  type: ${a.content_type} | category: ${a.category} | sources: ${urls}`);
+    console.log(`  published: ${a.published_at}`);
+    console.log();
+  }
+}
+
+void main();

--- a/src/lib/town-context.tsx
+++ b/src/lib/town-context.tsx
@@ -5,7 +5,6 @@ import {
   useContext,
   type PropsWithChildren,
 } from "react";
-import { usePathname } from "next/navigation";
 import type { TownConfig } from "@/lib/towns";
 
 const TownContext = createContext<TownConfig | null>(null);
@@ -33,19 +32,11 @@ export function townHref(townId: string, path = ""): string {
 
 export function useTownHref(path = ""): string {
   const town = useTown();
-  const pathname = usePathname();
   const normalizedPath = path
     ? path.startsWith("/")
       ? path
       : `/${path}`
     : "";
-
-  // When the user arrived via a root-rewritten URL (e.g. "/" or "/chat"),
-  // keep links root-relative so the URL bar stays clean.
-  const onRootPath = !pathname.startsWith(`/${town.town_id}`);
-  if (onRootPath) {
-    return normalizedPath || "/";
-  }
 
   return `/${town.town_id}${normalizedPath}`;
 }


### PR DESCRIPTION
## Summary

- **Navigation fix**: `useTownHref()` now always returns `/{town_id}{path}` — fixes broken first-click navigation from root `/` to subpages like `/daily-brief` and `/articles`
- **Expanded rewrites**: Added `articles`, `daily-brief`, `about` + nested `articles/:id` to `next.config.mjs` rewrite rules
- **Article generation**: Broadened `categorizeDocument()` to match ~30 more URL patterns. Added `generateFromAllDocuments()` for bulk backfill. Bumped doc query limit from 100→500
- **Bulk generation run**: 244+ articles generated from real ingested documents (still running)

## Root cause

When a user visited `/` (rewritten internally to `/needham`), `usePathname()` returned `/`. The old `useTownHref()` detected this as a "root path" and generated links like `/daily-brief` instead of `/needham/daily-brief`. Since `/daily-brief` had no rewrite rule, it 404'd on first click.

## Test plan

- [ ] Visit `http://localhost:3000/` → click "Read full brief" banner → should navigate to `/needham/daily-brief` (not 404)
- [ ] Click "Articles" in header → should navigate to `/needham/articles`
- [ ] Articles list should show 100+ articles from bulk generation
- [ ] Click any article → detail page loads with sources expanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)