### PR TITLE
feat: RSS/external news integration — unified community platform

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,24 @@
 
 ---
 
+## v0.10.0 — 2026-02-18
+
+**RSS/External News Integration — Unified Community Platform**
+
+### New Features
+- **External news ingestion** — Needham Patch, Needham Observer, and Needham Local are scraped every 4 hours via the connector framework; content stored in `content_items` with vector embeddings
+- **AI article summaries** — `summarizeExternalArticle()` generates reader-friendly AI summaries from external news; inserted as `ai_summary` articles with source attribution
+- **Automated article generation cron** (`/api/cron/generate`) — daily cron at 10 AM UTC generates articles from new documents + summarizes external news + creates daily brief
+- **Content items in RAG search** — `vectorSearchContentItems()` searches `content_items` in parallel with `document_chunks`; external news surfaces in both search and chat with a 0.95x ranking penalty so official content ranks higher
+- **Ingest cron** — `/api/cron/ingest` runs every 4 hours on Vercel to keep external sources fresh
+- **Patch RSS source config** — added `needham:patch-rss` (disabled — feed returns 404; scrape connector handles Patch)
+
+### Data
+- 40 external content items ingested (15 Patch, 15 Observer, 10 Needham Local)
+- 20 AI Summary articles generated from external news
+
+---
+
 ## v0.9.1 — 2026-02-17
 
 **Real Article Generation — Nuke Fake Seed Data**

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -100,6 +100,8 @@ AI-generated articles covering town news, government decisions, schools, public 
 - "Load more" to browse additional articles
 - Each article page shows: formatted content with headers and bullets, source type badge, clickable source links to official documents, AI disclaimer, thumbs up/down feedback, and an "Ask about this" button that opens chat pre-loaded with the article title
 - Articles are generated automatically each morning at 5 AM from newly ingested town documents
+- **External news integration** — AI summaries of articles from Needham Patch, Needham Observer, and Needham Local are generated alongside official town content. External sources are scraped every 4 hours and summarized daily.
+- External news appears in RAG-powered search and chat alongside official municipal content (official sources rank slightly higher)
 
 ### Daily Brief
 

--- a/scripts/generate-articles.ts
+++ b/scripts/generate-articles.ts
@@ -47,14 +47,14 @@ async function main() {
     errors.push(`Public records: ${msg}`);
   }
 
-  // Step 3: External articles (no-op until connector is built)
+  // Step 3: External articles (RSS/scrape → AI summary)
   console.log('\n📰 Summarizing external articles...');
   try {
     const articles = await summarizeExternalArticle();
     console.log(
       articles.length > 0
         ? `   ✅ ${articles.length} summaries generated`
-        : '   ℹ️  No external articles to process (connector not yet configured)'
+        : '   ℹ️  No new external articles to process'
     );
     totalGenerated += articles.length;
   } catch (error) {

--- a/scripts/seed-sources.ts
+++ b/scripts/seed-sources.ts
@@ -48,7 +48,22 @@ const NEEDHAM_SOURCES: SourceSeed[] = [
     should_embed: true,
   },
 
-  // Local News - Needham Patch
+  // Local News - Needham Patch (RSS — disabled, feed returns 404)
+  {
+    id: "needham:patch-rss",
+    town_id: "needham",
+    connector_type: "rss",
+    category: "news",
+    schedule: "hourly",
+    config: {
+      feedUrl: "https://patch.com/massachusetts/needham/feed",
+      sourceName: "Needham Patch",
+    },
+    enabled: false,
+    should_embed: true,
+  },
+
+  // Local News - Needham Patch (scrape fallback)
   {
     id: "needham:patch-news",
     town_id: "needham",

--- a/src/app/api/cron/generate/route.ts
+++ b/src/app/api/cron/generate/route.ts
@@ -1,0 +1,88 @@
+/**
+ * /api/cron/generate — Daily article generation
+ *
+ * Triggered by Vercel Cron (daily at 10:00 AM UTC / 5:00 AM Eastern).
+ * Runs after the ingest cron so new content_items are available.
+ *
+ * Pipeline:
+ * 1. Generate articles from new meeting minutes
+ * 2. Generate articles from new public records
+ * 3. Summarize external news (from content_items ingested by RSS/scrape)
+ * 4. Generate daily brief from today's articles
+ *
+ * Security: Protected by CRON_SECRET Bearer token.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  generateFromMeetingMinutes,
+  generateFromPublicRecord,
+  summarizeExternalArticle,
+  generateDailyBrief,
+} from "@/lib/article-generator";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // 5 minutes max for cron jobs
+
+export async function GET(request: NextRequest) {
+  // Verify cron secret (skip in development)
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  const startTime = Date.now();
+  let generated = 0;
+  let skipped = 0;
+  const errors: string[] = [];
+
+  // Step 1: Meeting minutes
+  try {
+    const articles = await generateFromMeetingMinutes();
+    generated += articles.length;
+  } catch (err) {
+    errors.push(`meeting_minutes: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // Step 2: Public records
+  try {
+    const articles = await generateFromPublicRecord();
+    generated += articles.length;
+  } catch (err) {
+    errors.push(`public_record: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // Step 3: External article summaries
+  try {
+    const articles = await summarizeExternalArticle();
+    generated += articles.length;
+  } catch (err) {
+    errors.push(`external: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // Step 4: Daily brief
+  try {
+    const brief = await generateDailyBrief();
+    if (brief) {
+      generated += 1;
+    } else {
+      skipped += 1;
+    }
+  } catch (err) {
+    errors.push(`daily_brief: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const durationMs = Date.now() - startTime;
+
+  return NextResponse.json({
+    timestamp: new Date().toISOString(),
+    generated,
+    skipped,
+    errors,
+    durationMs,
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,14 @@
     {
       "path": "/api/cron/monitor",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/ingest?town=needham",
+      "schedule": "0 */4 * * *"
+    },
+    {
+      "path": "/api/cron/generate",
+      "schedule": "0 10 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **External news ingestion**: Patch, Observer, and Needham Local scraped every 4 hours → `content_items` with vector embeddings
- **AI article summaries**: `summarizeExternalArticle()` generates reader-friendly summaries from external news, inserted as `ai_summary` articles
- **RAG search integration**: `vectorSearchContentItems()` searches `content_items` in parallel with `document_chunks` — external news appears in both search and chat (0.95x ranking penalty so official content stays on top)
- **Automated pipeline**: `/api/cron/ingest` (every 4h) + `/api/cron/generate` (daily 10am UTC) = fully autonomous content generation

## Files Changed
| File | Change |
|------|--------|
| `src/lib/article-generator.ts` | Replaced no-op `summarizeExternalArticle()` with real implementation (~100 lines) |
| `src/lib/rag.ts` | Added `vectorSearchContentItems()` + wired into `retrieveRelevantChunks()` |
| `src/app/api/cron/generate/route.ts` | **New** — daily cron endpoint for article generation |
| `vercel.json` | Added ingest (4h) and generate (daily) cron jobs |
| `scripts/seed-sources.ts` | Added Patch RSS entry (disabled — 404), kept scrape entries |
| `scripts/generate-articles.ts` | Updated comment from "no-op" to "RSS/scrape → AI summary" |
| `docs/USER_GUIDE.md` | Documented external news integration |
| `docs/RELEASE_NOTES.md` | v0.10.0 release notes |

## Data Generated
- 40 external content items ingested (15 Patch, 15 Observer, 10 Needham Local)
- 20 AI Summary articles generated

## Test plan
- [ ] Visit `/needham/articles` → filter by "AI Summary" → 20 external news summaries appear
- [ ] Search for a topic covered by Patch/Observer → external content surfaces alongside official docs
- [ ] Chat about local news → RAG includes external content in responses
- [ ] Build passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)