### PR TITLE
fix: resolve SonarCloud quality gate for A rating

### DIFF
--- a/.claude/skills/sonarcloud-fix/SKILL.md
+++ b/.claude/skills/sonarcloud-fix/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: sonarcloud-fix
+description: >
+  Automated SonarCloud issue detection and resolution. Fetches all open issues
+  from SonarCloud, categorizes them by severity, and applies fixes to achieve
+  and maintain an A rating across all dimensions (Reliability, Security, Maintainability).
+  Use this skill when: SonarCloud quality gate fails, before a release, during
+  code quality sweeps, or when asked to "fix sonarcloud issues".
+---
+
+# SonarCloud Issue Fixer
+
+You are an AI agent tasked with maintaining an A rating on SonarCloud for this project.
+
+## Project Info
+
+- **SonarCloud Organization:** `cmtemkin`
+- **SonarCloud Project Key:** `cmtemkin_needham-navigator`
+- **Analysis Mode:** Automatic (runs on SonarCloud's servers, not GitHub Actions)
+- **Config File:** `sonar-project.properties`
+
+## Step 1: Fetch Current Issues
+
+Use the SonarCloud public API to get all open issues:
+
+```bash
+# Get quality gate status
+curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=cmtemkin_needham-navigator" | python3 -m json.tool
+
+# Get all open issues (bugs, vulnerabilities, code smells)
+curl -s "https://sonarcloud.io/api/issues/search?componentKeys=cmtemkin_needham-navigator&resolved=false&ps=100" | python3 -m json.tool
+
+# Get current metrics
+curl -s "https://sonarcloud.io/api/measures/component?component=cmtemkin_needham-navigator&metricKeys=bugs,vulnerabilities,code_smells,security_hotspots,reliability_rating,security_rating,sqale_rating,duplicated_lines_density" | python3 -m json.tool
+
+# Get security hotspots that need review
+curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=cmtemkin_needham-navigator&status=TO_REVIEW" | python3 -m json.tool
+```
+
+## Step 2: Categorize and Prioritize
+
+Issues that block the quality gate (fix these FIRST):
+1. **Vulnerabilities** — directly affect Security Rating (A requires 0 vulnerabilities)
+2. **Bugs** — directly affect Reliability Rating
+3. **Security Hotspots** — unreviewed hotspots can affect Security Rating
+
+Issues that affect maintainability (fix these SECOND):
+4. **Code Smells** — affect Maintainability Rating (but A rating tolerates some)
+
+## Step 3: Apply Fixes by Rule Type
+
+### Common SonarCloud Rules and Fixes
+
+**`githubactions:S8233` — Workflow permissions too broad**
+- Move `permissions:` from workflow level to individual job level
+- Each job should only have the permissions it actually needs
+
+**`typescript:S6759` — Component props not read-only**
+- Wrap component props type with `Readonly<>`:
+  ```tsx
+  // Before
+  function Foo({ bar }: { bar: string }) { ... }
+  // After
+  function Foo({ bar }: Readonly<{ bar: string }>) { ... }
+  ```
+
+**`typescript:S7735` — Unexpected negated condition**
+- Flip the condition to use the positive form:
+  ```tsx
+  // Before
+  count !== 1 ? "s" : ""
+  // After
+  count === 1 ? "" : "s"
+  ```
+
+**`javascript:S6564` / `typescript:S6564` — Use `replaceAll` instead of `replace` with global regex**
+- Replace `.replace(/pattern/g, replacement)` with `.replaceAll("pattern", replacement)` when the regex is a simple literal
+- If the regex uses special characters or flags beyond `g`, keep `replace()` but note the exception
+
+**`css:S4649` — Insufficient color contrast**
+- Only applies to HTML files with inline styles
+- Fix by adjusting text color or background to meet WCAG AA (4.5:1 contrast ratio)
+- If the file is in `docs/` or is a mockup, add it to `sonar.exclusions` instead
+
+**`typescript:S5852` — Regex with potential super-linear backtracking**
+- Audit the regex: if it processes user-controlled input AND has nested quantifiers, fix it
+- If the regex only processes internal/controlled strings (like markdown formatting, internal IDs), it's a false positive — note this but don't change the code
+- Common safe patterns: `\*\*(.*?)\*\*`, `/#{1,6}\s*/`, `\[([^\]]+)\]\([^)]+\)` — these are all safe on short controlled strings
+
+**`S2245` — Pseudorandom number generator (PRNG)**
+- Only a real issue if used for security-sensitive purposes (tokens, passwords, encryption)
+- `Math.random()` for visitor IDs, UI animations, or cache busting is safe — note this
+
+### Fix Workflow
+
+For each issue:
+1. Read the flagged file and understand the context
+2. Determine if it's a real issue or a false positive
+3. If real: apply the minimal fix
+4. If false positive: document why it's safe (the issue will need to be manually dismissed in SonarCloud UI)
+
+## Step 4: Update Exclusions if Needed
+
+If SonarCloud is flagging files that shouldn't be analyzed (docs, mockups, test fixtures), update `sonar-project.properties`:
+
+```properties
+sonar.exclusions=**/node_modules/**,**/*.test.ts,**/*.test.tsx,scripts/**,docs/**,__tests__/**,supabase/**,config/**
+```
+
+## Step 5: Verify Locally
+
+```bash
+npm run lint
+npx tsc --noEmit
+npm run build
+```
+
+All three must pass before pushing.
+
+## Step 6: Push and Monitor
+
+1. Create a `fix/sonarcloud-*` branch
+2. Push and create a PR
+3. After merge, SonarCloud will re-analyze automatically (usually within 5-10 minutes)
+4. Verify the quality gate passes at: https://sonarcloud.io/project/overview?id=cmtemkin_needham-navigator
+
+## Target Ratings
+
+| Dimension | Target | What Affects It |
+|-----------|--------|-----------------|
+| Reliability | A | 0 bugs |
+| Security | A | 0 vulnerabilities |
+| Maintainability | A | Technical debt ratio < 5% |
+| Security Review | A | 80%+ hotspots reviewed |
+| Duplications | < 3% | Duplicated blocks/lines |

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -9,13 +9,12 @@ on:
     - cron: '0 5 * * 1'  # Every Monday at 5:00 AM UTC
   workflow_dispatch: {}
 
-permissions:
-  contents: write
-
 jobs:
   # Delete the head branch immediately after a PR is merged
   delete-on-merge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     steps:
       - name: Delete merged branch
@@ -41,6 +40,8 @@ jobs:
   # Weekly sweep: find and delete branches that were merged but never cleaned up
   sweep-stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,11 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  security-events: write
-
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       # Dummy values so the build doesn't fail on missing env vars
       OPENAI_API_KEY: sk-test-dummy-key-for-ci-build
@@ -55,6 +51,9 @@ jobs:
 
   codeql:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -70,6 +69,10 @@ jobs:
   auto-merge:
     needs: [build-and-test, codeql]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     if: success()
     steps:
       - name: Auto-merge PR
@@ -140,6 +143,9 @@ jobs:
   on-failure:
     needs: [build-and-test, codeql]
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     if: failure()
     steps:
       - name: Comment on PR with failure details

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,14 +9,13 @@ on:
     # Run weekly on Sundays at 2 AM UTC
     - cron: '0 2 * * 0'
 
-permissions:
-  security-events: write
-  contents: read
-
 jobs:
   analyze:
     name: Analyze with CodeQL
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/nightly-health-check.yml
+++ b/.github/workflows/nightly-health-check.yml
@@ -7,12 +7,11 @@ on:
   workflow_dispatch:
     # Allow manual trigger
 
-permissions:
-  issues: write
-
 jobs:
   health-check:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - name: Check production site
         id: health

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -7,14 +7,13 @@ on:
     # Run weekly on Mondays at 3 AM UTC
     - cron: '0 3 * * 1'
 
-permissions:
-  security-events: write
-  contents: read
-
 jobs:
   semgrep:
     name: Semgrep Scan
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
     container:
       image: semgrep/semgrep
 

--- a/src/app/[town]/articles/[id]/page.tsx
+++ b/src/app/[town]/articles/[id]/page.tsx
@@ -186,7 +186,7 @@ export default function ArticleDetailPage() {
                   <span>
                     {article.content_type === "ai_generated" && "AI Generated from "}
                     {article.content_type === "ai_summary" && "Summarized from "}
-                    {article.source_type ? (SOURCE_TYPE_LABELS[article.source_type] ?? article.source_type.replace(/_/g, " ")) : "Multiple Sources"}
+                    {article.source_type ? (SOURCE_TYPE_LABELS[article.source_type] ?? article.source_type.replaceAll("_", " ")) : "Multiple Sources"}
                   </span>
                   <span>•</span>
                   <span>{publishedDate}</span>
@@ -223,7 +223,7 @@ export default function ArticleDetailPage() {
                         </h2>
                         {article.source_type && (
                           <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
-                            {SOURCE_TYPE_LABELS[article.source_type] ?? article.source_type.replace(/_/g, " ")}
+                            {SOURCE_TYPE_LABELS[article.source_type] ?? article.source_type.replaceAll("_", " ")}
                           </span>
                         )}
                       </div>

--- a/src/app/api/admin/sources/seed/route.ts
+++ b/src/app/api/admin/sources/seed/route.ts
@@ -19,7 +19,7 @@ export async function POST(request: Request): Promise<Response> {
     const rows = CRAWL_SOURCES.map((src) => ({
       town_id: DEFAULT_TOWN_ID,
       url: src.url,
-      name: src.id.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()),
+      name: src.id.replaceAll("-", " ").replace(/\b\w/g, (c) => c.toUpperCase()),
       category: src.category,
       priority: src.priority,
       update_frequency: src.updateFrequency,

--- a/src/components/LiveWidgets.tsx
+++ b/src/components/LiveWidgets.tsx
@@ -220,7 +220,7 @@ function TransitWidget() {
         </div>
         {data.alertCount > 0 ? (
           <span className="text-[10px] font-semibold px-2 py-0.5 rounded bg-amber-50 text-amber-700 uppercase tracking-wider">
-            {data.alertCount} Alert{data.alertCount !== 1 ? "s" : ""}
+            {data.alertCount} Alert{data.alertCount === 1 ? "" : "s"}
           </span>
         ) : (
           <span className="text-[10px] font-semibold px-2 py-0.5 rounded bg-green-50 text-green-700 uppercase tracking-wider">On Time</span>
@@ -297,7 +297,7 @@ function WidgetSkeleton() {
   );
 }
 
-function WidgetFallback({ href, icon, title, message }: { href: string; icon: React.ReactNode; title: string; message: string }) {
+function WidgetFallback({ href, icon, title, message }: Readonly<{ href: string; icon: React.ReactNode; title: string; message: string }>) {
   return (
     <Link href={href} className="group block bg-white border border-border-default rounded-xl p-5 hover:border-[var(--primary)] hover:shadow-md transition-all">
       <div className="flex items-center gap-2 mb-3">


### PR DESCRIPTION
## Summary
- Move `permissions` from workflow level to job level in all 5 GitHub Actions workflows — fixes the single open vulnerability (`githubactions:S8233`) that was driving Security Rating to C and failing the quality gate
- Fix 4 code smells: `replace` → `replaceAll` (S6564), negated condition (S7735), readonly props (S6759)
- Add `sonarcloud-fix` skill (`.claude/skills/sonarcloud-fix/SKILL.md`) for automated SonarCloud issue detection and resolution going forward

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — 59 pages, zero errors
- [x] UI smoke test at localhost:3003
- [x] Verified test failures are pre-existing (same 16/99 on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)