### PR TITLE
fix: resolve 19 CodeQL security alerts

### DIFF
--- a/src/lib/connectors/rss.ts
+++ b/src/lib/connectors/rss.ts
@@ -89,15 +89,19 @@ function stripCdata(text: string): string {
   return text.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1").trim();
 }
 
+const HTML_ENTITY_MAP: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&nbsp;": " ",
+};
+
 function stripHtml(text: string): string {
   return text
     .replace(/<[^>]+>/g, " ")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
+    .replace(/&(?:amp|lt|gt|quot|nbsp|#39);/g, (entity) => HTML_ENTITY_MAP[entity] ?? entity)
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/src/lib/connectors/scraper.ts
+++ b/src/lib/connectors/scraper.ts
@@ -122,14 +122,12 @@ async function discoverLinks(
       if (!href) return;
 
       try {
-        const resolved = new URL(href, baseUrl).href;
-        // Only allow http/https URLs
-        if (
-          !resolved.startsWith("http://") &&
-          !resolved.startsWith("https://")
-        ) {
+        const parsedUrl = new URL(href, baseUrl);
+        // Only allow http/https URLs (blocks javascript:, data:, vbscript:, etc.)
+        if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
           return;
         }
+        const resolved = parsedUrl.href;
         // Skip fragment-only links
         if (resolved.includes("#")) {
           return;

--- a/src/lib/pendo.ts
+++ b/src/lib/pendo.ts
@@ -18,12 +18,12 @@ type PageType =
 
 /** Generate or retrieve a persistent anonymous visitor ID */
 export function getVisitorId(): string {
-  if (typeof window === 'undefined') return 'server';
+  if (typeof globalThis.window === 'undefined') return 'server';
 
   const STORAGE_KEY = 'nn_visitor_id';
   let id = localStorage.getItem(STORAGE_KEY);
   if (!id) {
-    id = `anon-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    id = `anon-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
     localStorage.setItem(STORAGE_KEY, id);
   }
   return id;
@@ -31,7 +31,7 @@ export function getVisitorId(): string {
 
 /** Generate or retrieve the first-seen timestamp for this visitor */
 function getFirstSeen(): string {
-  if (typeof window === 'undefined') return new Date().toISOString();
+  if (typeof globalThis.window === 'undefined') return new Date().toISOString();
 
   const STORAGE_KEY = 'nn_first_seen';
   let firstSeen = localStorage.getItem(STORAGE_KEY);
@@ -44,9 +44,9 @@ function getFirstSeen(): string {
 
 /** Initialize Pendo with visitor and account data */
 export function initializePendo(townId: string, townName: string): void {
-  if (!PENDO_API_KEY || typeof window === 'undefined') return;
+  if (!PENDO_API_KEY || typeof globalThis.window === 'undefined') return;
 
-  const pendo = window.pendo;
+  const pendo = globalThis.pendo;
   if (!pendo) return;
 
   pendo.initialize({
@@ -84,10 +84,10 @@ export function resolvePageType(pathname: string, query?: string): PageType {
 
 /** Track a page view from the current browser URL */
 export function trackCurrentPageView(townId: string): void {
-  if (typeof window === "undefined") return;
+  if (typeof globalThis.window === "undefined") return;
 
-  const path = window.location.pathname;
-  const query = new URLSearchParams(window.location.search).get("q")?.trim() ?? "";
+  const path = globalThis.location.pathname;
+  const query = new URLSearchParams(globalThis.location.search).get("q")?.trim() ?? "";
 
   trackEvent("page_view", {
     town_id: townId,
@@ -99,8 +99,8 @@ export function trackCurrentPageView(townId: string): void {
 
 /** Track a custom event in Pendo */
 export function trackEvent(eventName: string, metadata?: Record<string, unknown>): void {
-  if (typeof window === 'undefined') return;
-  const pendo = window.pendo;
+  if (typeof globalThis.window === 'undefined') return;
+  const pendo = globalThis.pendo;
   if (!pendo?.track) return;
 
   pendo.track(eventName, {

--- a/src/pendo.d.ts
+++ b/src/pendo.d.ts
@@ -24,6 +24,7 @@ declare global {
   interface Window {
     pendo?: Pendo;
   }
+  var pendo: Pendo | undefined;
 }
 
 export {};


### PR DESCRIPTION
## Summary
- Replace `Math.random()` with `crypto.randomUUID()` for anonymous visitor IDs in `pendo.ts` — resolves 17 `js/insecure-randomness` alerts that were flagged at every `trackEvent()` call site
- Single-pass HTML entity decoding via lookup map in RSS connector — resolves `js/double-escaping` alert
- Use `URL.protocol` instead of `startsWith()` for URL scheme validation in scraper — resolves `js/incomplete-url-scheme-check` alert
- Bonus: migrated `window` → `globalThis` references in pendo.ts for SSR safety

## Test plan
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean  
- [x] `npm run build` — 59 pages, zero errors
- [x] UI smoke test at localhost:3003

🤖 Generated with [Claude Code](https://claude.com/claude-code)