### PR TITLE
fix: resolve cold-start search failures — retry logic, non-fatal text search, maxDuration

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -105,6 +105,8 @@ function staticStreamResponse(options: {
   });
 }
 
+export const maxDuration = 60;
+
 export async function POST(request: Request): Promise<Response> {
   let body: ChatRequestBody;
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { getSupabaseClient } from "@/lib/supabase";
+
+/**
+ * GET /api/health — Lightweight health check that also warms up
+ * the serverless function so the search/chat API routes stay responsive.
+ *
+ * Called by Vercel cron to prevent cold starts, and also used by
+ * CI health-check workflows.
+ */
+export async function GET(): Promise<Response> {
+  const start = performance.now();
+
+  try {
+    // Warm up the Supabase connection (shared across API routes)
+    const supabase = getSupabaseClient({});
+    const { count, error } = await supabase
+      .from("document_chunks")
+      .select("id", { count: "exact", head: true });
+
+    const durationMs = Math.round(performance.now() - start);
+
+    if (error) {
+      return NextResponse.json(
+        { status: "degraded", error: error.message, duration_ms: durationMs },
+        { status: 503 }
+      );
+    }
+
+    return NextResponse.json({
+      status: "ok",
+      chunk_count: count,
+      duration_ms: durationMs,
+    });
+  } catch (error) {
+    const durationMs = Math.round(performance.now() - start);
+    return NextResponse.json(
+      {
+        status: "error",
+        error: error instanceof Error ? error.message : "Unknown error",
+        duration_ms: durationMs,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -151,6 +151,8 @@ function deduplicateByUrl(results: SearchResult[]): SearchResult[] {
   return deduplicated;
 }
 
+export const maxDuration = 60;
+
 export async function POST(request: Request): Promise<Response> {
   const start = performance.now();
 

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/daily",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/health",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Extended `maxDuration` to 60s** on `/api/search` and `/api/chat` routes to survive Vercel cold starts
- **Added client-side retry-once logic** in `SearchHomePage` and `TownChatPage` — retries after 2s on non-200 responses instead of silently showing empty results
- **Made text search non-fatal** in `hybridSearch()` — when Supabase full-text search times out, semantic (vector) search results still come through
- **Lazy-loaded CohereClient** via `require()` to reduce cold start payload
- **Added `/api/health` endpoint + hourly Vercel cron** to keep serverless functions warm

## Root Cause
Production search returned HTTP 500 on cold starts because:
1. Heavy dependency loading (OpenAI SDK, Supabase, Cohere, AI SDK) took ~38s, exceeding the default 10s timeout
2. `Promise.all` in `hybridSearch()` rejected entirely when `textSearchChunks` threw a Supabase statement timeout, discarding working semantic results
3. Client code silently swallowed 500 errors, showing "No results found" with no retry

## Files Changed
- `src/app/api/search/route.ts` — added `maxDuration = 60`
- `src/app/api/chat/route.ts` — added `maxDuration = 60`
- `src/components/SearchHomePage.tsx` — retry-once for `/api/search` and `/api/chat`
- `src/components/TownChatPage.tsx` — retry-once for `/api/chat`
- `src/lib/rag.ts` — lazy `getCohereClient()`, non-fatal `textSearchChunks` in `hybridSearch()`
- `src/app/api/health/route.ts` — new health check endpoint
- `vercel.json` — added hourly health cron
- `docs/RELEASE_NOTES.md` — v0.11.2 entry

## Test plan
- [x] `npm run lint` — passes
- [x] `npx tsc --noEmit` — passes
- [x] `npm run build` — 60 pages, zero errors
- [x] `npm test` — 134 tests pass across 13 suites
- [x] Local smoke test: searched "dump sticker" on localhost:3000/needham — returns results
- [ ] Production verification after deploy: wait 10+ min for cold start, then search

🤖 Generated with [Claude Code](https://claude.com/claude-code)