### PR TITLE
fix: remove hourly health cron — Vercel Hobby plan daily limit

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,6 @@
     {
       "path": "/api/cron/daily",
       "schedule": "0 6 * * *"
-    },
-    {
-      "path": "/api/health",
-      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Removed `/api/health` hourly cron (`0 * * * *`) from `vercel.json`
- Vercel Hobby plan only allows cron jobs that run **once per day** — the hourly schedule was causing deployment failures
- The daily `/api/cron/daily` cron (6 AM UTC) is unaffected

## Test plan
- [ ] Vercel deployment succeeds (no more cron limit error)
- [ ] `/api/health` endpoint still works when called directly (just not auto-scheduled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)