### PR TITLE
fix: clean up chat loading state and auto-scroll on navigation

### DIFF
--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -32,9 +32,8 @@ export function ChatBubble({ message, onFollowupClick, sessionId }: ChatBubblePr
         <div className="w-[30px] h-[30px] rounded-full bg-gradient-to-br from-primary to-primary-light flex items-center justify-center text-white text-xs font-extrabold shrink-0 mt-0.5">
           N
         </div>
-        <div className="bg-white border border-border-light rounded-2xl rounded-bl-md px-[18px] py-3.5 shadow-xs flex items-center gap-2">
+        <div className="bg-white border border-border-light rounded-2xl rounded-bl-md px-[18px] py-3.5 shadow-xs flex items-center">
           <TypingDots />
-          <span className="text-[13px] text-text-secondary">Thinking...</span>
         </div>
       </div>
     );
@@ -112,7 +111,7 @@ export function ChatBubble({ message, onFollowupClick, sessionId }: ChatBubblePr
 
 function TypingDots() {
   return (
-    <div className="inline-flex gap-1 items-center py-1">
+    <div className="inline-flex gap-1 items-center py-1" aria-label="Thinking">
       <span className="w-1.5 h-1.5 bg-text-muted rounded-full animate-blink" />
       <span className="w-1.5 h-1.5 bg-text-muted rounded-full animate-blink [animation-delay:0.2s]" />
       <span className="w-1.5 h-1.5 bg-text-muted rounded-full animate-blink [animation-delay:0.4s]" />

--- a/src/components/search/FloatingChat.tsx
+++ b/src/components/search/FloatingChat.tsx
@@ -50,6 +50,14 @@ export const FloatingChat = forwardRef<FloatingChatHandle, FloatingChatProps>(
     const hasProcessedInitial = useRef(false);
     const latestAiMessageIdRef = useRef<string | null>(null);
 
+    const scrollToBottom = useCallback(() => {
+      requestAnimationFrame(() => {
+        if (messagesContainerRef.current) {
+          messagesContainerRef.current.scrollTop = messagesContainerRef.current.scrollHeight;
+        }
+      });
+    }, []);
+
     const scrollToLatestAiMessage = useCallback(() => {
       if (!latestAiMessageIdRef.current || !messagesContainerRef.current) return;
 
@@ -221,10 +229,11 @@ export const FloatingChat = forwardRef<FloatingChatHandle, FloatingChatProps>(
         if (message.trim()) {
           setTimeout(() => {
             sendMessage(message, { isFromSearch: true });
+            setTimeout(scrollToBottom, 50);
           }, 100);
         }
       },
-      [pathname, sendMessage, townId]
+      [pathname, sendMessage, townId, scrollToBottom]
     );
 
     const openWithContext = useCallback(
@@ -256,15 +265,17 @@ export const FloatingChat = forwardRef<FloatingChatHandle, FloatingChatProps>(
         ];
         setMessages(contextMessages);
         setIsOpen(true);
+        setTimeout(scrollToBottom, 100);
 
         // If a follow-up message is provided, send it after context is loaded
         if (options.message?.trim()) {
           setTimeout(() => {
             sendMessage(options.message!, { isFromSearch: true });
+            setTimeout(scrollToBottom, 50);
           }, 150);
         }
       },
-      [pathname, sendMessage, townId]
+      [pathname, sendMessage, townId, scrollToBottom]
     );
 
     useImperativeHandle(ref, () => ({


### PR DESCRIPTION
## Summary

- **Loading state**: Removed redundant "Thinking..." text from chat loading bubble — now shows only the 3 animated dots (standard chat UX pattern). Added `aria-label="Thinking"` for screen readers.
- **Auto-scroll**: Chat now auto-scrolls to the latest message when opened from search results (both "Ask about this" and follow-up flows).

## Test plan

- [x] `npm run lint` — zero errors
- [x] `npx tsc --noEmit` — zero errors  
- [x] `npm run build` — zero errors
- [x] `npm test` — 134/134 passing
- [ ] Open chat, ask a question → loading shows only dots, no text
- [ ] Search → click "Ask about this" → chat scrolls to new question

🤖 Generated with [Claude Code](https://claude.com/claude-code)