### PR TITLE
feat: calendar events open in modal instead of inline panel

### DIFF
--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo } from "react";
 import { ChevronLeft, ChevronRight, List, LayoutGrid, Rss } from "lucide-react";
 import { CalendarGrid } from "./CalendarGrid";
 import { EventDetailPanel } from "./EventDetailPanel";
+import { EventModal } from "./EventModal";
 
 // Re-export EventItem for other calendar components
 export interface EventItem {
@@ -146,10 +147,17 @@ export function CalendarView({ townId, townName }: Readonly<CalendarViewProps>) 
     setSelectedDate(null);
   };
 
+  // Only open modal when date has events
+  const handleSelectDate = useCallback((date: Date) => {
+    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    const dayEvents = eventsByDate.get(key) ?? [];
+    setSelectedDate(dayEvents.length > 0 ? date : null);
+  }, [eventsByDate]);
+
   const goToToday = () => {
     const now = new Date();
     setCurrentMonth(new Date(now.getFullYear(), now.getMonth(), 1));
-    setSelectedDate(now);
+    handleSelectDate(now);
   };
 
   const subscribeUrl = globalThis.window
@@ -302,14 +310,15 @@ export function CalendarView({ townId, townName }: Readonly<CalendarViewProps>) 
                 month={currentMonth}
                 eventsByDate={eventsByDate}
                 selectedDate={selectedDate}
-                onSelectDate={setSelectedDate}
+                onSelectDate={handleSelectDate}
                 getSourceColor={getSourceColor}
               />
-              {selectedDate && (
-                <EventDetailPanel
+              {selectedDate && selectedDateEvents.length > 0 && (
+                <EventModal
                   date={selectedDate}
                   events={selectedDateEvents}
                   getSourceColor={getSourceColor}
+                  onClose={() => setSelectedDate(null)}
                 />
               )}
             </>

--- a/src/components/calendar/EventDetailPanel.tsx
+++ b/src/components/calendar/EventDetailPanel.tsx
@@ -1,117 +1,14 @@
 "use client";
 
-import { Calendar, Clock, MapPin, ExternalLink } from "lucide-react";
-import { AddToCalendar } from "./AddToCalendar";
+import { Calendar } from "lucide-react";
+import { EventRow } from "./EventRow";
 import type { EventItem } from "./CalendarView";
-import { formatEasternTime, EASTERN_TZ } from "@/lib/timezone";
 
 interface EventDetailPanelProps {
   date?: Date;
   events: EventItem[];
   getSourceColor: (sourceId: string) => { bg: string; text: string; dot: string; label: string };
   isListView?: boolean;
-}
-
-function formatEventDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  return d.toLocaleDateString("en-US", {
-    timeZone: EASTERN_TZ,
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-function EventRow({
-  event,
-  getSourceColor,
-}: Readonly<{
-  event: EventItem;
-  getSourceColor: (sourceId: string) => { bg: string; text: string; dot: string; label: string };
-}>) {
-  const start = event.metadata?.event_start
-    ? new Date(event.metadata.event_start)
-    : new Date(event.published_at);
-  const eventEndStr = event.metadata?.event_end;
-  const end = eventEndStr ? new Date(eventEndStr) : null;
-  const source = getSourceColor(event.source_id);
-
-  return (
-    <div className="group bg-white border border-border-default rounded-lg hover:border-[var(--primary)] hover:shadow-sm transition-all p-4">
-      <div className="flex flex-col sm:flex-row sm:items-start gap-3">
-        {/* Date badge */}
-        <div className="flex shrink-0 items-center gap-2 w-fit">
-          <div className="flex flex-col items-center justify-center w-14 h-14 rounded-lg bg-[var(--primary)]/10 text-[var(--primary)]">
-            <span className="text-[10px] font-semibold uppercase leading-tight">
-              {start.toLocaleDateString("en-US", { month: "short" })}
-            </span>
-            <span className="text-lg font-bold leading-tight -mt-0.5">
-              {start.getDate()}
-            </span>
-          </div>
-        </div>
-
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2 mb-1.5">
-            <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium ${source.bg} ${source.text}`}>
-              <span className={`w-1.5 h-1.5 rounded-full ${source.dot}`} />
-              {source.label}
-            </span>
-          </div>
-
-          <h3 className="font-bold text-text-primary group-hover:text-[var(--primary)] transition-colors mb-1.5 text-base">
-            {event.url ? (
-              <a href={event.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
-                {event.title}
-              </a>
-            ) : (
-              event.title
-            )}
-          </h3>
-
-          <div className="flex flex-col gap-1 text-sm text-text-secondary">
-            <div className="flex items-center gap-1.5">
-              <Clock size={14} className="shrink-0 text-text-muted" />
-              <span>
-                {formatEventDate(event.metadata?.event_start || event.published_at)}
-                {event.metadata?.event_start && (
-                  <> at {formatEasternTime(event.metadata.event_start)}</>
-                )}
-                {end && eventEndStr && <>{" – "}{formatEasternTime(eventEndStr)}</>}
-              </span>
-            </div>
-            {event.metadata?.event_location && (
-              <div className="flex items-center gap-1.5">
-                <MapPin size={14} className="shrink-0 text-text-muted" />
-                <span>{event.metadata.event_location}</span>
-              </div>
-            )}
-          </div>
-
-          {(event.summary || event.content) && (
-            <p className="mt-2 line-clamp-2 text-sm text-text-secondary leading-relaxed">
-              {event.summary || event.content?.slice(0, 200)}
-            </p>
-          )}
-
-          <div className="flex items-center gap-3 mt-3">
-            <AddToCalendar event={event} />
-            {event.url && (
-              <a
-                href={event.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-sm font-medium text-[var(--primary)] hover:underline"
-              >
-                View details <ExternalLink size={12} />
-              </a>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
 }
 
 export function EventDetailPanel({

--- a/src/components/calendar/EventModal.tsx
+++ b/src/components/calendar/EventModal.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { X, Calendar } from "lucide-react";
+import { EventRow } from "./EventRow";
+import type { EventItem } from "./CalendarView";
+
+interface EventModalProps {
+  date: Date;
+  events: EventItem[];
+  getSourceColor: (sourceId: string) => { bg: string; text: string; dot: string; label: string };
+  onClose: () => void;
+}
+
+export function EventModal({ date, events, getSourceColor, onClose }: Readonly<EventModalProps>) {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Escape key to close
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  // Lock body scroll
+  useEffect(() => {
+    const original = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, []);
+
+  // Focus modal on open
+  useEffect(() => {
+    modalRef.current?.focus();
+  }, []);
+
+  const dateLabel = date.toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/30 animate-in fade-in-0 duration-200"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Modal positioning wrapper */}
+      <div className="fixed inset-0 z-50 flex items-end sm:items-center sm:justify-center p-0 sm:p-4">
+        {/* Modal content */}
+        <div
+          ref={modalRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Events for ${dateLabel}`}
+          tabIndex={-1}
+          className="w-full bg-white shadow-xl flex flex-col max-h-[85vh] sm:max-h-[80vh] rounded-t-2xl sm:rounded-2xl sm:max-w-xl animate-in fade-in-0 slide-in-from-bottom-4 duration-300 outline-none"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-border-default px-5 py-4 shrink-0">
+            <div>
+              <h2 className="text-base font-bold text-text-primary flex items-center gap-2">
+                <Calendar size={18} className="text-[var(--primary)]" />
+                {dateLabel}
+              </h2>
+              <p className="text-xs text-text-secondary mt-0.5">
+                {events.length} event{events.length !== 1 ? "s" : ""}
+              </p>
+            </div>
+            <button
+              onClick={onClose}
+              className="rounded-lg p-2 text-text-secondary hover:bg-surface hover:text-text-primary transition-colors"
+              aria-label="Close"
+            >
+              <X size={20} />
+            </button>
+          </div>
+
+          {/* Scrollable event list */}
+          <div className="flex-1 overflow-y-auto p-4 space-y-3">
+            {events.map((event) => (
+              <EventRow key={event.id} event={event} getSourceColor={getSourceColor} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/calendar/EventRow.tsx
+++ b/src/components/calendar/EventRow.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Clock, MapPin, ExternalLink } from "lucide-react";
+import { AddToCalendar } from "./AddToCalendar";
+import type { EventItem } from "./CalendarView";
+import { formatEasternTime, EASTERN_TZ } from "@/lib/timezone";
+
+export function formatEventDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-US", {
+    timeZone: EASTERN_TZ,
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function EventRow({
+  event,
+  getSourceColor,
+}: Readonly<{
+  event: EventItem;
+  getSourceColor: (sourceId: string) => { bg: string; text: string; dot: string; label: string };
+}>) {
+  const start = event.metadata?.event_start
+    ? new Date(event.metadata.event_start)
+    : new Date(event.published_at);
+  const eventEndStr = event.metadata?.event_end;
+  const end = eventEndStr ? new Date(eventEndStr) : null;
+  const source = getSourceColor(event.source_id);
+
+  return (
+    <div className="group bg-white border border-border-default rounded-lg hover:border-[var(--primary)] hover:shadow-sm transition-all p-4">
+      <div className="flex flex-col sm:flex-row sm:items-start gap-3">
+        {/* Date badge */}
+        <div className="flex shrink-0 items-center gap-2 w-fit">
+          <div className="flex flex-col items-center justify-center w-14 h-14 rounded-lg bg-[var(--primary)]/10 text-[var(--primary)]">
+            <span className="text-[10px] font-semibold uppercase leading-tight">
+              {start.toLocaleDateString("en-US", { month: "short" })}
+            </span>
+            <span className="text-lg font-bold leading-tight -mt-0.5">
+              {start.getDate()}
+            </span>
+          </div>
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 mb-1.5">
+            <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium ${source.bg} ${source.text}`}>
+              <span className={`w-1.5 h-1.5 rounded-full ${source.dot}`} />
+              {source.label}
+            </span>
+          </div>
+
+          <h3 className="font-bold text-text-primary group-hover:text-[var(--primary)] transition-colors mb-1.5 text-base">
+            {event.url ? (
+              <a href={event.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                {event.title}
+              </a>
+            ) : (
+              event.title
+            )}
+          </h3>
+
+          <div className="flex flex-col gap-1 text-sm text-text-secondary">
+            <div className="flex items-center gap-1.5">
+              <Clock size={14} className="shrink-0 text-text-muted" />
+              <span>
+                {formatEventDate(event.metadata?.event_start || event.published_at)}
+                {event.metadata?.event_start && (
+                  <> at {formatEasternTime(event.metadata.event_start)}</>
+                )}
+                {end && eventEndStr && <>{" – "}{formatEasternTime(eventEndStr)}</>}
+              </span>
+            </div>
+            {event.metadata?.event_location && (
+              <div className="flex items-center gap-1.5">
+                <MapPin size={14} className="shrink-0 text-text-muted" />
+                <span>{event.metadata.event_location}</span>
+              </div>
+            )}
+          </div>
+
+          {(event.summary || event.content) && (
+            <p className="mt-2 line-clamp-2 text-sm text-text-secondary leading-relaxed">
+              {event.summary || event.content?.slice(0, 200)}
+            </p>
+          )}
+
+          <div className="flex items-center gap-3 mt-3">
+            <AddToCalendar event={event} />
+            {event.url && (
+              <a
+                href={event.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm font-medium text-[var(--primary)] hover:underline"
+              >
+                View details <ExternalLink size={12} />
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Calendar events now open in a modal overlay** instead of rendering inline below the calendar grid (which pushed content down)
- **Desktop**: centered modal (max-width 600px) with scrollable event list
- **Mobile**: bottom-sheet style that slides up from the bottom of the screen
- **Accessibility**: `role="dialog"`, `aria-modal`, Escape to close, focus management, body scroll lock
- **DRY refactor**: Extracted `EventRow` into its own file — shared by both the modal (month view) and the list view

## Changes
| File | Change |
|------|--------|
| `src/components/calendar/EventRow.tsx` | **NEW** — Extracted from EventDetailPanel |
| `src/components/calendar/EventModal.tsx` | **NEW** — Modal with backdrop, animations, a11y |
| `src/components/calendar/EventDetailPanel.tsx` | Removed internal EventRow, imports from EventRow.tsx |
| `src/components/calendar/CalendarView.tsx` | Month view uses EventModal; dates with no events don't open modal |

## Test plan
- [ ] Click a date with events on the calendar → modal opens showing event cards
- [ ] Click the backdrop or X button → modal closes
- [ ] Press Escape → modal closes
- [ ] Scroll within modal when multiple events exist
- [ ] Resize browser to mobile width → modal becomes bottom-sheet
- [ ] "Add to Calendar" dropdown works inside the modal
- [ ] Switch to List view → events still render inline (no modal)
- [ ] Navigate months → modal closes
- [ ] "Today" button opens modal only if today has events

🤖 Generated with [Claude Code](https://claude.com/claude-code)