### PR TITLE
feat: daily brief citation footnotes + LLM-generated follow-up questions

### DIFF
--- a/src/app/[town]/daily-brief/page.tsx
+++ b/src/app/[town]/daily-brief/page.tsx
@@ -1,12 +1,94 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 import { ChevronDown, ChevronRight, Calendar } from "lucide-react";
 import { useTown } from "@/lib/town-context";
 import type { Article, ArticleListResponse } from "@/types/article";
 import ReactMarkdown from "react-markdown";
+import { transformBriefCitations } from "@/lib/brief-citations";
+import { BriefSourceFootnotes } from "@/components/BriefSourceFootnotes";
+
+/** Renders footnote-annotated [N] markers as styled superscripts in markdown text nodes. */
+const footnoteComponents = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  p: ({ children, ...props }: any) => (
+    <p {...props}>{styleFootnoteRefs(children)}</p>
+  ),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  li: ({ children, ...props }: any) => (
+    <li {...props}>{styleFootnoteRefs(children)}</li>
+  ),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  strong: ({ children, ...props }: any) => (
+    <strong {...props}>{styleFootnoteRefs(children)}</strong>
+  ),
+};
+
+function styleFootnoteRefs(children: React.ReactNode): React.ReactNode {
+  if (typeof children === "string") {
+    const parts = children.split(/(\[\d+\])/g);
+    if (parts.length === 1) return children;
+    return parts.map((part, i) => {
+      const match = /^\[(\d+)\]$/.exec(part);
+      if (match) {
+        return (
+          <sup key={i} className="text-[var(--primary)] font-bold text-[10px] ml-0.5">
+            [{match[1]}]
+          </sup>
+        );
+      }
+      return part;
+    });
+  }
+  if (Array.isArray(children)) {
+    return children.map((child, i) => <span key={i}>{styleFootnoteRefs(child)}</span>);
+  }
+  return children;
+}
+
+function BriefCard({ brief, label, dateLabel }: Readonly<{ brief: Article; label: string; dateLabel: string }>) {
+  const { body: transformedBody, footnotes } = useMemo(
+    () => transformBriefCitations(brief.body, brief.source_urls, brief.source_names),
+    [brief.body, brief.source_urls, brief.source_names],
+  );
+
+  return (
+    <div className="bg-white rounded-lg p-8 shadow-sm border border-border-default mb-8">
+      <div className="flex items-center gap-2 mb-6">
+        <span className="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-800">
+          {label}
+        </span>
+        <span className="text-sm text-text-muted">{dateLabel}</span>
+      </div>
+
+      <h2 className="text-3xl font-bold text-text-primary mb-6">{brief.title}</h2>
+
+      <div className="prose prose-slate max-w-none">
+        <ReactMarkdown components={footnoteComponents}>{transformedBody}</ReactMarkdown>
+      </div>
+
+      <BriefSourceFootnotes footnotes={footnotes} briefDate={brief.published_at} />
+    </div>
+  );
+}
+
+function ExpandedBriefBody({ brief }: Readonly<{ brief: Article }>) {
+  const { body: transformedBody, footnotes } = useMemo(
+    () => transformBriefCitations(brief.body, brief.source_urls, brief.source_names),
+    [brief.body, brief.source_urls, brief.source_names],
+  );
+
+  return (
+    <div className="px-5 pb-5 border-t border-border-light pt-5">
+      <div className="prose prose-slate max-w-none">
+        <ReactMarkdown components={footnoteComponents}>{transformedBody}</ReactMarkdown>
+      </div>
+      <BriefSourceFootnotes footnotes={footnotes} briefDate={brief.published_at} />
+    </div>
+  );
+}
 
 export default function DailyBriefPage() {
   const town = useTown();
@@ -99,48 +181,7 @@ export default function DailyBriefPage() {
           ) : (
             <>
               {todayBrief ? (
-                <div className="bg-white rounded-lg p-8 shadow-sm border border-border-default mb-8">
-                  <div className="flex items-center gap-2 mb-6">
-                    <span className="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-800">
-                      {"Today's Brief"}
-                    </span>
-                    <span className="text-sm text-text-muted">{today}</span>
-                  </div>
-
-                  <h2 className="text-3xl font-bold text-text-primary mb-6">{todayBrief.title}</h2>
-
-                  <div className="prose prose-slate max-w-none"><ReactMarkdown>{todayBrief.body}</ReactMarkdown></div>
-
-                  {todayBrief.source_urls && todayBrief.source_urls.length > 0 && (
-                    <div className="mt-8 pt-6 border-t border-border-light">
-                      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wide mb-3">
-                        Sources
-                      </h3>
-                      <ul className="space-y-1">
-                        {todayBrief.source_urls.map((url, i) => {
-                          let hostname: string;
-                          try {
-                            hostname = new URL(url).hostname.replace(/^www\./, "");
-                          } catch {
-                            hostname = url;
-                          }
-                          return (
-                            <li key={`source-${url}`}>
-                              <a
-                                href={url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-sm text-[var(--primary)] hover:underline"
-                              >
-                                {todayBrief.source_names?.[i] || hostname}
-                              </a>
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    </div>
-                  )}
-                </div>
+                <BriefCard brief={todayBrief} label="Today's Brief" dateLabel={today} />
               ) : (
                 <div className="bg-white rounded-lg p-12 shadow-sm border border-border-default mb-8 text-center">
                   <div className="text-6xl mb-4">📰</div>
@@ -190,9 +231,7 @@ export default function DailyBriefPage() {
                           </button>
 
                           {isExpanded && (
-                            <div className="px-5 pb-5 border-t border-border-light pt-5">
-                              <div className="prose prose-slate max-w-none"><ReactMarkdown>{brief.body}</ReactMarkdown></div>
-                            </div>
+                            <ExpandedBriefBody brief={brief} />
                           )}
                         </div>
                       );

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -325,7 +325,27 @@ export async function POST(request: Request): Promise<Response> {
           });
         }
 
-        const cleanedText = fullText.replaceAll(/USED_SOURCES:\s*.+?(?:\n|$)/gi, "").trim();
+        // Parse FOLLOW_UPS metadata from LLM output
+        const followUpsMatch = /FOLLOW_UPS:\s*(.+?)(?:\n|$)/i.exec(fullText);
+        if (followUpsMatch) {
+          const followUps = followUpsMatch[1]
+            .split("|")
+            .map((q) => q.trim())
+            .filter((q) => q.length > 0)
+            .slice(0, 3);
+          if (followUps.length > 0) {
+            writer.write({
+              type: "data-followups",
+              data: followUps,
+              transient: true,
+            });
+          }
+        }
+
+        const cleanedText = fullText
+          .replaceAll(/USED_SOURCES:\s*.+?(?:\n|$)/gi, "")
+          .replaceAll(/FOLLOW_UPS:\s*.+?(?:\n|$)/gi, "")
+          .trim();
 
         // Fire-and-forget: log token usage and cost
         Promise.resolve(result.usage).then((usage) => {

--- a/src/components/BriefSourceFootnotes.tsx
+++ b/src/components/BriefSourceFootnotes.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { ExternalLink } from "lucide-react";
+import type { Footnote } from "@/lib/brief-citations";
+
+interface BriefSourceFootnotesProps {
+  footnotes: Footnote[];
+  briefDate: string;
+}
+
+export function BriefSourceFootnotes({ footnotes, briefDate }: Readonly<BriefSourceFootnotesProps>) {
+  if (footnotes.length === 0) return null;
+
+  const formattedDate = new Date(briefDate).toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+  });
+
+  return (
+    <div className="mt-8 pt-6 border-t border-border-light">
+      <h3 className="text-sm font-semibold text-text-muted uppercase tracking-wide mb-3">
+        Sources
+      </h3>
+      <div className="flex flex-wrap gap-2">
+        {footnotes.map((fn) => (
+          <a
+            key={`fn-${fn.number}`}
+            href={fn.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-[5px] max-w-[320px] px-2.5 py-[5px] bg-surface border border-border-default rounded-md text-[11.5px] text-primary font-medium hover:border-primary hover:bg-[#EBF0F8] transition-all cursor-pointer no-underline"
+          >
+            <span className="font-bold text-text-muted shrink-0">[{fn.number}]</span>
+            <ExternalLink size={10} className="shrink-0" />
+            <span className="truncate">{fn.name}</span>
+            <span className="text-text-muted truncate"> &middot; {formattedDate}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SearchHomePage.tsx
+++ b/src/components/SearchHomePage.tsx
@@ -147,7 +147,7 @@ type AIAnswerState =
   | { type: "idle" }
   | { type: "loading" }
   | { type: "cached"; answer: CachedAnswer }
-  | { type: "loaded"; html: string; sources: { title: string; url: string; date?: string }[] }
+  | { type: "loaded"; html: string; sources: { title: string; url: string; date?: string }[]; followUps?: string[] }
   | { type: "error"; message: string };
 
 function normalizeQuery(value: string | null): string {
@@ -300,6 +300,7 @@ export function SearchHomePage({ initialQuery = "" }: Readonly<SearchHomePagePro
 
             let answerHtml = "";
             let sources: { title: string; url: string; date?: string }[] = [];
+            let followUps: string[] = [];
             const decoder = new TextDecoder();
 
             while (true) {
@@ -330,6 +331,11 @@ export function SearchHomePage({ initialQuery = "" }: Readonly<SearchHomePagePro
                       date: s.date,
                     }));
                   }
+
+                  // Handle follow-up questions
+                  if (parsed.type === "data-followups") {
+                    followUps = (parsed.data ?? []) as string[];
+                  }
                 } catch {
                   // Skip malformed JSON
                 }
@@ -338,7 +344,7 @@ export function SearchHomePage({ initialQuery = "" }: Readonly<SearchHomePagePro
 
             const cleanedHtml = stripInternalMetadata(answerHtml);
             if (cleanedHtml) {
-              setAiAnswer({ type: "loaded", html: cleanedHtml, sources });
+              setAiAnswer({ type: "loaded", html: cleanedHtml, sources, followUps });
             } else {
               setAiAnswer({ type: "error", message: "No answer generated" });
             }
@@ -789,6 +795,7 @@ export function SearchHomePage({ initialQuery = "" }: Readonly<SearchHomePagePro
                 state="loaded"
                 answerHtml={aiAnswer.html}
                 sources={aiAnswer.sources}
+                followUps={aiAnswer.followUps}
                 onFollowUp={handleFollowUp}
               />
             )}

--- a/src/components/TownChatPage.tsx
+++ b/src/components/TownChatPage.tsx
@@ -345,6 +345,7 @@ function ChatContent() {
 
         let confidence: "high" | "medium" | "low" | undefined;
         let sources: NonNullable<ChatMessage["sources"]> = [];
+        let followUps: string[] = [];
 
         await parseStreamResponse(response, {
           onText: () => {
@@ -357,9 +358,12 @@ function ChatContent() {
           onSources: (srcs) => {
             sources = srcs;
           },
+          onFollowUps: (fups) => {
+            followUps = fups;
+          },
           onDone: (cleanedText) => {
             completeResponse(
-              { id: `ai-${crypto.randomUUID().slice(0, 8)}`, role: "ai", text: cleanedText || "No response received.", sources, confidence, followups: [] },
+              { id: `ai-${crypto.randomUUID().slice(0, 8)}`, role: "ai", text: cleanedText || "No response received.", sources, confidence, followups: followUps },
               startTime
             );
           },
@@ -507,12 +511,13 @@ function ChatContent() {
 
   const showWelcome = messages.length === 0 && !isTyping;
 
-  // Compute follow-up suggestions from the last AI message
+  // Compute follow-up suggestions from the last AI message.
+  // Prefer LLM-generated follow-ups (rendered inside ChatBubble); fall back to keyword matching.
   const followUpSuggestions = useMemo(() => {
     if (isTyping || messages.length === 0) return [];
     const lastMsg = messages[messages.length - 1];
     if (lastMsg.role !== "ai") return [];
-    // If the message already has followups from the API/mock, use those
+    // If the message already has followups from the API/mock, ChatBubble renders them
     if (lastMsg.followups && lastMsg.followups.length > 0) return [];
     return getFollowUpSuggestions(lastMsg.text);
   }, [messages, isTyping]);

--- a/src/components/search/AIAnswerCard.tsx
+++ b/src/components/search/AIAnswerCard.tsx
@@ -18,6 +18,7 @@ type AIAnswerCardProps =
       state: "loaded";
       answerHtml: string;
       sources: { title: string; url: string; date?: string }[];
+      followUps?: string[];
       onFollowUp: (question: string) => void;
     }
   | {
@@ -71,11 +72,13 @@ function FollowUpInput({ onSubmit }: Readonly<{ onSubmit: (question: string) => 
 function AnswerBody({
   html,
   sources,
+  followUps,
   onFollowUp,
   badge,
 }: Readonly<{
   html: string;
   sources: { title: string; url: string; date?: string }[];
+  followUps?: string[];
   onFollowUp: (question: string) => void;
   badge?: React.ReactNode;
 }>) {
@@ -103,6 +106,21 @@ function AnswerBody({
         <div className="flex flex-wrap gap-1.5 mb-3">
           {sources.map((source) => (
             <SourceChip key={source.url ?? source.title} source={source} />
+          ))}
+        </div>
+      )}
+
+      {/* LLM-generated follow-up suggestion chips */}
+      {followUps && followUps.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {followUps.map((question) => (
+            <button
+              key={question}
+              onClick={() => onFollowUp(question)}
+              className="px-3.5 py-[7px] bg-white border border-border-default rounded-[20px] text-[12.5px] text-text-secondary font-medium hover:border-primary hover:text-primary hover:bg-[#F5F8FC] transition-all cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            >
+              {question}
+            </button>
           ))}
         </div>
       )}
@@ -180,6 +198,7 @@ export function AIAnswerCard(props: AIAnswerCardProps) {
     <AnswerBody
       html={props.answerHtml}
       sources={props.sources}
+      followUps={props.followUps}
       onFollowUp={props.onFollowUp}
     />
   );

--- a/src/lib/brief-citations.ts
+++ b/src/lib/brief-citations.ts
@@ -1,0 +1,66 @@
+/**
+ * Transforms daily brief markdown from inline source links to numbered footnotes.
+ *
+ * Input:  "**Topic**: Detail text ([source](https://example.com/page))"
+ * Output: "**Topic**: Detail text [1]"
+ * + footnotes array with number, url, name
+ */
+
+export interface Footnote {
+  number: number;
+  url: string;
+  name: string;
+}
+
+export interface TransformedBrief {
+  body: string;
+  footnotes: Footnote[];
+}
+
+const SOURCE_LINK_PATTERN = /\(\[source\]\((https?:\/\/[^)]+)\)\)/g;
+
+export function transformBriefCitations(
+  body: string,
+  sourceUrls?: string[] | null,
+  sourceNames?: string[] | null,
+): TransformedBrief {
+  if (!body) return { body: "", footnotes: [] };
+
+  const urlToNumber = new Map<string, number>();
+  const footnotes: Footnote[] = [];
+  let counter = 0;
+
+  // Build a URL → name lookup from the article's source metadata
+  const urlToName = new Map<string, string>();
+  if (sourceUrls && sourceNames) {
+    for (let i = 0; i < sourceUrls.length; i++) {
+      if (sourceUrls[i] && sourceNames[i]) {
+        urlToName.set(sourceUrls[i], sourceNames[i]);
+      }
+    }
+  }
+
+  const transformed = body.replaceAll(SOURCE_LINK_PATTERN, (_match, url: string) => {
+    let num = urlToNumber.get(url);
+    if (num === undefined) {
+      counter++;
+      num = counter;
+      urlToNumber.set(url, num);
+
+      // Determine display name: prefer source_names, fall back to hostname
+      let name = urlToName.get(url);
+      if (!name) {
+        try {
+          name = new URL(url).hostname.replace(/^www\./, "");
+        } catch {
+          name = url;
+        }
+      }
+
+      footnotes.push({ number: num, url, name });
+    }
+    return `[${num}]`;
+  });
+
+  return { body: transformed, footnotes };
+}

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -54,6 +54,19 @@ USED_SOURCES: [list of source IDs you actually referenced, e.g., "S1, S3, S5"]
 
 Only list source IDs for chunks you actually used to formulate your answer. If you don't use a chunk, don't list it. If no chunks are relevant to the question, write "USED_SOURCES: none" and explain that you don't have information on that topic.
 
+FOLLOW-UP QUESTIONS (INTERNAL USE ONLY):
+After your USED_SOURCES line, add another metadata line:
+FOLLOW_UPS: Question 1 | Question 2 | Question 3
+
+Generate 2-3 specific, contextual follow-up questions that a resident would naturally ask next based on your answer. Make them:
+- Specific to the topic you just answered (not generic)
+- Actionable (things the resident might actually need to know next)
+- Short (under 60 characters each)
+- Separated by " | "
+
+Example: If the answer is about building permits, good follow-ups would be:
+FOLLOW_UPS: What are the permit fees? | How long does approval take? | Can I apply online?
+
 UNDERSTANDING RESIDENT LANGUAGE:
 Residents often use informal language. "The dump" means the Transfer Station. "Cops" means the Police Department. "Can I build a deck" is a zoning/permit question. "Who do I call about a rat" is a Board of Health question. Always interpret questions charitably and match them to the most relevant town service.
 

--- a/src/lib/stream-parser.ts
+++ b/src/lib/stream-parser.ts
@@ -11,6 +11,8 @@ export interface StreamCallbacks {
   onSources?: (sources: MockSource[]) => void;
   /** Called when confidence data arrives */
   onConfidence?: (confidence: "high" | "medium" | "low") => void;
+  /** Called when follow-up questions arrive */
+  onFollowUps?: (followUps: string[]) => void;
   /** Called when the stream completes */
   onDone?: (fullText: string) => void;
   /** Called when an error occurs */
@@ -79,6 +81,9 @@ export async function parseStreamResponse(
                 })
               );
               callbacks.onSources?.(sources);
+            } else if (data.type === "data-followups") {
+              const followUps = (data.data ?? []) as string[];
+              callbacks.onFollowUps?.(followUps);
             }
           } catch (err) {
             // Skip invalid JSON chunks (common in SSE streams)

--- a/src/lib/text-utils.ts
+++ b/src/lib/text-utils.ts
@@ -6,7 +6,11 @@
  * Strip internal LLM metadata (e.g. USED_SOURCES lines) before displaying to users.
  */
 export function stripInternalMetadata(text: string): string {
-  return text.replaceAll(/\n?USED_SOURCES:\s*.+?(?:\n|$)/gi, "\n").replaceAll(/^\n+|\n+$/g, "").trim();
+  return text
+    .replaceAll(/\n?USED_SOURCES:\s*.+?(?:\n|$)/gi, "\n")
+    .replaceAll(/\n?FOLLOW_UPS:\s*.+?(?:\n|$)/gi, "\n")
+    .replaceAll(/^\n+|\n+$/g, "")
+    .trim();
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Daily brief citations**: Replaces inline `([source](url))` links with numbered footnote superscripts `[1]`, `[2]` etc. Bottom of each brief now shows SourceChip-style pills with title, external link icon, and date metadata. Works retroactively on all past briefs (render-time transformation).
- **LLM-generated follow-up questions**: Replaces crude keyword-matching follow-ups with contextual AI-generated questions. The LLM now generates 2-3 specific follow-up questions streamed as a new `data-followups` SSE event. Rendered as clickable chips on both chat and search pages. Free-text input preserved.
- **Previous briefs now show sources**: Expanded previous daily briefs now show citation footnotes (previously had no source display at all).

## Files changed
- `src/lib/brief-citations.ts` — **NEW** — Core citation transformation utility (regex parsing, URL dedup, footnote numbering)
- `src/components/BriefSourceFootnotes.tsx` — **NEW** — Renders footnote pills with ExternalLink icon, title, and date
- `src/app/[town]/daily-brief/page.tsx` — Uses citation transformer + footnote component for today's and previous briefs
- `src/lib/prompts.ts` — Adds FOLLOW_UPS instruction block to LLM system prompt
- `src/app/api/chat/route.ts` — Parses FOLLOW_UPS from LLM output, streams as `data-followups` SSE event
- `src/lib/stream-parser.ts` — Handles new `data-followups` callback
- `src/lib/text-utils.ts` — Strips FOLLOW_UPS metadata from displayed text
- `src/components/TownChatPage.tsx` — Wires follow-ups from stream to chat messages
- `src/components/SearchHomePage.tsx` — Parses and passes follow-ups to AIAnswerCard
- `src/components/search/AIAnswerCard.tsx` — Renders follow-up chips above free-text input

## Test plan
- [ ] Visit `/needham/daily-brief` — inline sources should show as `[1]`, `[2]` superscripts with numbered pills at bottom
- [ ] Expand a previous brief — should also show citation footnotes
- [ ] Ask a question in chat — 2-3 contextual follow-up chips should appear below AI answer
- [ ] Click a follow-up chip — sends as new chat message
- [ ] Search page — same follow-up behavior on AI answer card
- [ ] Free-text follow-up input still works on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)